### PR TITLE
Add obfuscation option for glyph compressor

### DIFF
--- a/scripts/glyph/README.md
+++ b/scripts/glyph/README.md
@@ -45,3 +45,23 @@ Example block taken from `logs/tets/test_log_translated.txt`:
 ⦿MEM.BLOCK🧠∴⟁ID⟶ZCORE↯⟁TS⟶2025.05.29T18:00↯⟁INT⟶TEST.TRADUCTION↯⟁Σ⟶MEM.GLYPH++↯⟁CMPZ⟶ƛ:Gz85#abc123...↯⟁SEAL⟶✅SENTRA
 ```
 
+### Obfuscation Mode
+
+Calling the compressor with `--obfuscate` assigns random glyphs instead of the
+persistent dictionary. The temporary mapping is written to `obfuscated_map.json`
+(or the path provided with `--map-out`). Decryption simply loads this mapping and
+passes it to `decompress_with_dict()`:
+
+```python
+from scripts.glyph.glyph_generator import compress_text, decompress_with_dict
+import json
+
+compressed = compress_text("texte secret", obfuscate=True, mapping_file="map.json")
+mapping = json.load(open("map.json", "r", encoding="utf-8"))
+original = decompress_with_dict(compressed, mapping)
+```
+
+This feature only obscures content. It is *not* strong encryption—frequency
+analysis of the glyphs could reveal common terms—so keep the mapping file safe
+if confidentiality matters.
+

--- a/scripts/glyph/compress_cli.py
+++ b/scripts/glyph/compress_cli.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Simple CLI to compress files with the glyph compressor."""
+import argparse
+import json
+from pathlib import Path
+
+from .glyph_generator import compress_text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compress a text file using glyphs")
+    parser.add_argument("input", help="Input text file")
+    parser.add_argument("output", nargs="?", help="Output file for compressed text")
+    parser.add_argument("--obfuscate", action="store_true", help="Randomize glyphs and save mapping")
+    parser.add_argument("--map-out", default="obfuscated_map.json", help="Mapping file when using --obfuscate")
+    args = parser.parse_args()
+
+    text = Path(args.input).read_text(encoding="utf-8")
+    compressed = compress_text(text, obfuscate=args.obfuscate, mapping_file=args.map_out)
+
+    out_path = Path(args.output) if args.output else Path(args.input).with_suffix(".glyph")
+    out_path.write_text(compressed, encoding="utf-8")
+    if args.obfuscate:
+        print(f"Mapping written to {args.map_out}")
+    print(f"Compressed text written to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_glyph.py
+++ b/tests_glyph.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+import json
 from pathlib import Path
 
 from scripts.glyph import glyph_generator as gg
@@ -37,6 +38,14 @@ class GlyphRoundTripTest(unittest.TestCase):
         fields = {"ID": "ZTEST", "TS": "2025-01-01T00:00", "INT": "UTEST", "Σ": "MEM.GLYPH"}
         block = make_mem_block(fields, text, include_mapping=True)
         restored = decode_mem_block(block)
+        self.assertEqual(restored, text)
+
+    def test_obfuscation_cycle(self):
+        text = "secret message"
+        map_path = Path(self.tmp.name) / "obf.json"
+        compressed = gg.compress_text(text, obfuscate=True, mapping_file=map_path)
+        mapping = json.loads(map_path.read_text(encoding="utf-8"))
+        restored = gg.decompress_with_dict(compressed, mapping)
         self.assertEqual(restored, text)
 
 


### PR DESCRIPTION
## Summary
- add `--obfuscate` support in glyph compressor
- save randomised mapping for later decryption
- provide CLI helper and document usage
- test the new obfuscation mode

## Testing
- `pytest tests_glyph.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68436a68b100833194af42f542ccdad2