### PR TITLE
Improve glyph docs

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -111,7 +111,12 @@ $ ./sentra_cycle.bat          # Windows
 $ bash sentra_cycle.sh        # Linux/macOS
 ```
 
-Ce script effectue **encode → load → sync → report**, puis pousse sur la branche `dev`.
+Ce script enchaîne :
+1. **encode** – traduit les logs en glyphes et met à jour `glyph_dict.json`.
+2. **load** – insère le résultat compressé dans `sentra_memory.json`.
+3. **sync** – envoie la mémoire vers Notion et Discord.
+4. **report** – crée `reports/YYYY/MM/YYYY-MM-DD_rapport.md`.
+5. Push Git automatique sur la branche `dev`.
 
 ### 5.2  Exemples de commandes manuelles
 
@@ -163,6 +168,24 @@ Le **dispatcher** (dans `orchestrator.py`) mappe automatiquement l’intention d
 
 * Alphabet étendu (unicode privé) + dictionnaire adaptatif.
 * Cible : **×10** de compression.
+
+### 8.3  Ajouter un jeu de glyphes
+
+1. Créez un fichier JSON dans `memory/` (ex : `glyph_dict_custom.json`).
+2. Définissez la variable `GLYPH_DICT_PATH` pour pointer vers ce fichier.
+3. Les agents l’utiliseront automatiquement pour générer ou lire les glyphes.
+
+### 8.4  Partage et sauvegarde du dictionnaire
+
+* Versionnez `glyph_dict.json` via Git pour tracer l’historique.
+* Effectuez une copie compressée (`gzip glyph_dict.json`) après chaque session.
+* Un dictionnaire propre améliore le taux de compression global.
+
+### 8.5  Obfuscation
+
+La fonction `make_mem_block()` peut exclure la table de correspondance
+(`include_mapping=False`). Le texte compressé reste alors lisible
+uniquement par les agents possédant le dictionnaire.
 
 ---
 

--- a/scripts/glyph/README.md
+++ b/scripts/glyph/README.md
@@ -28,6 +28,29 @@ print(compressed)
 print(decompress_text(compressed))
 ```
 
+## Adding New Glyph Sets
+
+1. Create a new JSON dictionary such as `memory/glyph_dict_custom.json`.
+2. Set the environment variable `GLYPH_DICT_PATH` to this file.
+3. Use `glyph_watcher.py` or `pipeline_traducteur.py` to populate it.
+
+## Sharing the Dictionary
+
+All agents read from the path given in `GLYPH_DICT_PATH`. Point this variable
+to a common location (network share or repository) so every agent uses the same
+mapping table.
+
+## Backup and Versioning
+
+Commit `glyph_dict.json` to Git and keep a compressed copy with:
+`gzip -k memory/glyph_dict.json`. Archiving the dictionary preserves its
+evolution and can slightly improve compression over time.
+
+## Obfuscation Mode
+
+Pass `include_mapping=False` to `make_mem_block()` to omit the glyph table.
+Only agents with the dictionary will be able to decode the block.
+
 ## Tests
 
 A suite `tests_glyph.py` uses `unittest` to verify that compressing then


### PR DESCRIPTION
## Summary
- document cycle steps in `NOTICE.md`
- add sections on custom glyph sets, sharing dictionaries and obfuscation
- expand glyph environment README

## Testing
- `python -m pytest -q tests_glyph.py`

------
https://chatgpt.com/codex/tasks/task_e_68436a69d48c83318b879ff9c5545c0d