### PR TITLE
Add CLI compression tests

### DIFF
--- a/tests_glyph.py
+++ b/tests_glyph.py
@@ -1,10 +1,15 @@
 import os
 import tempfile
 import unittest
+import subprocess
+import sys
+import base64
+import zlib
 from pathlib import Path
 
 from scripts.glyph import glyph_generator as gg
 from scripts.glyph import make_mem_block, decode_mem_block
+from scripts import zmem_encoder
 
 
 class GlyphRoundTripTest(unittest.TestCase):
@@ -38,6 +43,61 @@ class GlyphRoundTripTest(unittest.TestCase):
         block = make_mem_block(fields, text, include_mapping=True)
         restored = decode_mem_block(block)
         self.assertEqual(restored, text)
+
+    def test_zmem_encoder_cycle(self):
+        text = "compression zmem locale"
+        base = Path(self.tmp.name)
+        zlib_txt = base / "out.l64.t"
+        zlib_bin = base / "out.l64.b"
+        zmem_src = base / "out.src"
+        zmem_bin = base / "out.zmem"
+        index = base / "index.json"
+
+        zmem_encoder.encode_zmem(
+            content=text,
+            ctx_tag="TCTX",
+            zlib_txt_out=str(zlib_txt),
+            zlib_bin_out=str(zlib_bin),
+            zmem_src_out=str(zmem_src),
+            zmem_bin_out=str(zmem_bin),
+            update_dict_path=str(index),
+        )
+
+        decoded = zlib.decompress(base64.b64decode(zmem_bin.read_text())).decode("utf-8")
+        self.assertEqual(decoded, text)
+        if zlib_bin.exists():
+            decoded2 = zlib.decompress(zlib_bin.read_bytes()).decode("utf-8")
+            self.assertEqual(decoded2, text)
+
+    def test_batch_cli_outputs(self):
+        sample = "<note>demo de batch</note>"
+        input_path = Path(self.tmp.name) / "sample.txt"
+        input_path.write_text(sample, encoding="utf-8")
+        script = Path(__file__).resolve().parent / "scripts" / "run_auto_translator.py"
+        result = subprocess.run(
+            [sys.executable, str(script), "-i", str(input_path)],
+            cwd=self.tmp.name,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Pipeline complet exécuté", result.stdout)
+
+        out_txt = Path(self.tmp.name) / f"{input_path.stem}.zlib.txt"
+        out_bin = Path(self.tmp.name) / f"{input_path.stem}.zlib"
+        zmem_src = Path(self.tmp.name) / "memory_zia" / "sentra_memory.zmem.src"
+        zmem_bin = Path(self.tmp.name) / "memory_zia" / "sentra_memory.zmem"
+        dict_file = Path(self.tmp.name) / "memory_zia" / "mem_dict.json"
+
+        for f in (out_txt, out_bin, zmem_src, zmem_bin, dict_file):
+            self.assertTrue(f.exists(), f"Missing {f}")
+
+        comp_txt = out_txt.read_text(encoding="utf-8")
+        self.assertEqual(zlib.decompress(out_bin.read_bytes()).decode("utf-8"), comp_txt)
+        self.assertEqual(
+            zlib.decompress(base64.b85decode(zmem_bin.read_bytes())).decode("utf-8"),
+            zmem_src.read_text(encoding="utf-8"),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend glyph tests to cover zmem and CLI compression modes
- verify decompression of each method returns original text
- run `run_auto_translator.py` in a temp dir and check generated files

## Testing
- `python tests_glyph.py -v`

------
https://chatgpt.com/codex/tasks/task_e_68436c0319c08331add04dd5b1091f0c