### PR TITLE
Fix glyph utilities tests

### DIFF
--- a/scripts/compressor.py
+++ b/scripts/compressor.py
@@ -1,0 +1,18 @@
+"""Compatibility wrapper for moved compressor module."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+# allow running as a standalone script
+if __name__ == "__main__" and __package__ is None:
+    ROOT = pathlib.Path(__file__).resolve().parent.parent
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+
+from scripts.glyph.compressor import *  # noqa: F401,F403
+
+if __name__ == "__main__":  # pragma: no cover - passthrough to real entrypoint
+    main()
+

--- a/scripts/glyph/compressor.py
+++ b/scripts/glyph/compressor.py
@@ -16,8 +16,14 @@ EMOJI_POOL = list("😀😁😂🤣😃😄😅😆😉😊😋😎🥳🤖👾�
 class Compressor:
     """Generic text compressor with multiple modes."""
 
+    _ALIAS = {
+        "visual": "glyph",
+        "abbrev": "abbr",
+        "alphanumeric": "alphanum",
+    }
+
     def __init__(self, mode: str = "glyph", dict_dir: pathlib.Path | None = None):
-        self.mode = mode
+        self.mode = self._ALIAS.get(mode, mode)
         self.dict_dir = pathlib.Path(dict_dir) if dict_dir else DEFAULT_DICT_DIR
         self.mapping = self._load_dict()
 
@@ -42,6 +48,10 @@ class Compressor:
             json.dumps(self.mapping, indent=2, ensure_ascii=False),
             encoding="utf-8",
         )
+
+    # backward compatibility
+    def _save_mapping(self) -> None:
+        self._save_dict()
 
     # ------------------------------------------------------------------
     # Token generation
@@ -97,6 +107,13 @@ class Compressor:
             text = text.replace(token, term)
         return text
 
+    # Compatibility aliases
+    def compress(self, text: str) -> str:
+        return self.compress_text(text)
+
+    def decompress(self, text: str) -> str:
+        return self.decompress_text(text)
+
 # ----------------------------------------------------------------------
 # CLI entry point
 
@@ -104,7 +121,7 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Compress/decompress text")
     parser.add_argument("input", help="Input text file")
     parser.add_argument("output", help="Output text file")
-    parser.add_argument("--mode", default="glyph", choices=["glyph", "emoji", "abbr", "alphanum"], help="Compression mode")
+    parser.add_argument("--mode", default="glyph", help="Compression mode")
     parser.add_argument("--decompress", action="store_true", help="Decompress instead of compress")
     args = parser.parse_args(argv)
 
@@ -118,3 +135,4 @@ def main(argv: list[str] | None = None) -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/scripts/glyph/glyph_generator.py
+++ b/scripts/glyph/glyph_generator.py
@@ -66,10 +66,14 @@ def compress_text(
             used.add(glyph)
         for w, glyph in mapping.items():
             pattern = rf"\b{re.escape(w)}\b"
-            text = re.sub(pattern, lambda _m, g=glyph: g, text)
-        out = pathlib.Path(mapping_file or "obfuscated_map.json")
-        out.write_text(json.dumps(mapping, indent=2, ensure_ascii=False), encoding="utf-8")
-        return text
+            text = re.sub(pattern, glyph, text)
+        out_path = pathlib.Path(mapping_file) if mapping_file else None
+        if out_path is None:
+            out_path = pathlib.Path("obfuscated_map.json")
+        out_path.write_text(json.dumps(mapping, indent=2, ensure_ascii=False), encoding="utf-8")
+        if mapping_file:
+            return text
+        return text, mapping
 
     # regular mode using persistent dictionary
     for w in set(words):


### PR DESCRIPTION
## Summary
- add `scripts/compressor.py` compatibility wrapper
- improve `Compressor` with mode aliases, CLI update and helper methods
- extend `glyph_generator.compress_text` to handle obfuscation mapping
- update batch compression helpers and expose `compress_directory`
- fix wrapper execution when run as standalone script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684563fc06808331aae7c3c7ab458197