### PR TITLE
Fix config JSON and glyph imports

### DIFF
--- a/configs/config.json
+++ b/configs/config.json
@@ -1,7 +1,4 @@
 {
-import os
-  openai.api_key = os.getenv("OPENAI_API_KEY")
-
   "model": "gpt-4",
   "temperature": 0.5,
   "max_tokens": 2048

--- a/scripts/glyph/batch_compress.py
+++ b/scripts/glyph/batch_compress.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from typing import Iterable, Tuple
 
 from .glyph_generator import compress_text
-from .mem_block import make_mem_block
+from scripts.mem_block import make_mem_block
 
 def compress_content(text: str, mode: str, obfuscate: bool, src_name: str = "") -> str:
     """Compress text using glyph or zlib, option obfuscate (MEM.BLOCK sans mapping)."""

--- a/scripts/glyph/glyph_generator.py
+++ b/scripts/glyph/glyph_generator.py
@@ -66,7 +66,7 @@ def compress_text(
             used.add(glyph)
         for w, glyph in mapping.items():
             pattern = rf"\b{re.escape(w)}\b"
-            text = re.sub(pattern, glyph, text)
+            text = re.sub(pattern, lambda _m, g=glyph: g, text)
         out_path = pathlib.Path(mapping_file) if mapping_file else None
         if out_path is None:
             out_path = pathlib.Path("obfuscated_map.json")
@@ -112,7 +112,7 @@ def compress_with_dict(text: str, mapping: Dict[str, str]) -> str:
             used.add(glyph)
     for term, glyph in mapping.items():
         pattern = rf"\b{re.escape(term)}\b"
-        text = re.sub(pattern, glyph, text)
+        text = re.sub(pattern, lambda _m, g=glyph: g, text)
     return text
 
 def randomize_mapping(mapping: Dict[str, str]) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- clean up configs/config.json to remove stray Python
- correct import path for make_mem_block
- ensure glyph substitution uses safe lambda replacement

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684590109c788331bb89ba12c692ba5d