### PR TITLE
Implement memory reading API

### DIFF
--- a/scripts/glyph/mem_block.py
+++ b/scripts/glyph/mem_block.py
@@ -1,0 +1,1 @@
+from ..mem_block import *  # re-export helper functions


### PR DESCRIPTION
## Summary
- add `/read_note` endpoint for searching notes
- provide stub `scripts/glyph/mem_block.py` to fix imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845901483048331b161baa85d40eb49