### PR TITLE
Implement git auto-commit after note/file write

### DIFF
--- a/scripts/git_utils.py
+++ b/scripts/git_utils.py
@@ -1,0 +1,28 @@
+import subprocess
+from typing import Iterable
+
+__all__ = ["commit_changes"]
+
+
+def commit_changes(files: Iterable[str], message: str) -> None:
+    """Add, commit and push specified files to git.
+
+    Parameters
+    ----------
+    files : Iterable[str]
+        Paths to files to add and commit.
+    message : str
+        Commit message.
+
+    Raises
+    ------
+    RuntimeError
+        If any git command fails.
+    """
+    paths = list(files)
+    try:
+        subprocess.run(["git", "add", *paths], check=True)
+        subprocess.run(["git", "commit", "-m", message], check=True)
+        subprocess.run(["git", "push"], check=True)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Git command failed: {e}")

--- a/scripts/glyph/batch_compress.py
+++ b/scripts/glyph/batch_compress.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from typing import Iterable, Tuple
 
 from .glyph_generator import compress_text
-from .mem_block import make_mem_block
+from scripts.mem_block import make_mem_block
 
 def compress_content(text: str, mode: str, obfuscate: bool, src_name: str = "") -> str:
     """Compress text using glyph or zlib, option obfuscate (MEM.BLOCK sans mapping)."""

--- a/scripts/glyph/compress_cli.py
+++ b/scripts/glyph/compress_cli.py
@@ -5,7 +5,7 @@ import argparse
 import json
 from pathlib import Path
 
-from .mem_block import make_mem_block
+from scripts.mem_block import make_mem_block
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Compresse un texte en MEM.BLOCK glyphique (avec ou sans mapping, obfuscation possible)")


### PR DESCRIPTION
## Summary
- add `scripts/git_utils.py` helper for git add/commit/push
- commit changes after `/write_note` and `/write_file` endpoints update a file
- return HTTP 500 if git commands fail
- fix imports in glyph modules for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459015d1c8833195688b5b9733989b