### PR TITLE
Add FastAPI support

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn -w 1 -b 0.0.0.0:$PORT scripts.discord_bot:app
+web: uvicorn scripts.api_sentra:app --host 0.0.0.0 --port $PORT
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ python scripts/zmem_encoder.py -i docs/mon_texte.txt -n TEST/MEM
 python scripts/compose_prompt.py TEST/MEM
 ```
 
+### Démarrer l'API FastAPI
+Pour tester localement l'API (plugin ChatGPT), lancez :
+
+```bash
+uvicorn scripts.api_sentra:app --reload --port 5000
+```
+
 ## 📁 Structure
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ discord.py>=2.5.0,<2.6.0
 python-dotenv==1.0.1
 requests==2.32.1
 unicodedata2 ; sys_platform == 'win32'
+
+fastapi
+uvicorn

--- a/scripts/glyph/batch_compress.py
+++ b/scripts/glyph/batch_compress.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from typing import Iterable, Tuple
 
 from .glyph_generator import compress_text
-from .mem_block import make_mem_block
+from ..mem_block import make_mem_block
 
 def compress_content(text: str, mode: str, obfuscate: bool, src_name: str = "") -> str:
     """Compress text using glyph or zlib, option obfuscate (MEM.BLOCK sans mapping)."""

--- a/scripts/glyph/glyph_generator.py
+++ b/scripts/glyph/glyph_generator.py
@@ -66,7 +66,7 @@ def compress_text(
             used.add(glyph)
         for w, glyph in mapping.items():
             pattern = rf"\b{re.escape(w)}\b"
-            text = re.sub(pattern, glyph, text)
+            text = re.sub(pattern, lambda _m, g=glyph: g, text)
         out_path = pathlib.Path(mapping_file) if mapping_file else None
         if out_path is None:
             out_path = pathlib.Path("obfuscated_map.json")


### PR DESCRIPTION
## Summary
- include `fastapi` and `uvicorn` in dependencies
- document how to run the FastAPI API in the README
- run the FastAPI app in the Procfile
- fix path bug in `batch_compress.py`
- fix glyph obfuscation issue in `glyph_generator.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845901cdaa88331890884856d0aad20