### PR TITLE
Update API for project-aware notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ docs/       → MANUEL, README, rapports Markdown
 ## 🌐 Endpoints API
 
 Un serveur *FastAPI* (voir `scripts/api_sentra.py`) expose plusieurs routes pour interagir avec la mémoire :
-- `POST /write_note` – ajoute une note textuelle dans la mémoire
+- `POST /write_note` – ajoute une note textuelle dans la mémoire (paramètre `project` optionnel)
 - `GET /get_notes` – lit le fichier JSON complet (lecture de note)
 - `GET /read_note` – recherche des notes par mot-clé ou affiche les dernières
-- `GET /get_memorial` – renvoie le journal Markdown du projet
+- `GET /get_memorial` – renvoie le journal Markdown du projet choisi
 - `POST /write_file` – crée ou met à jour un fichier dans `projects/<projet>/fichiers/`
 - `POST /reprise` – résume un canal Discord
 - `GET /check_env` – vérifie la clé API (debug)
@@ -90,16 +90,19 @@ Un serveur *FastAPI* (voir `scripts/api_sentra.py`) expose plusieurs routes pour
 ### Exemples `curl`
 
 ```bash
-# Écrire une note
+# Écrire une note dans le projet "sentra_core"
 curl -X POST http://localhost:8000/write_note \
      -H "Content-Type: application/json" \
-     -d '{"text": "Nouvelle note"}'
+     -d '{"text": "Nouvelle note", "project": "sentra_core"}'
 
 # Lire la mémoire JSON
 curl http://localhost:8000/get_notes
 
 # Rechercher dans la mémoire
 curl "http://localhost:8000/read_note?term=project"
+
+# Lire le journal Markdown du projet
+curl "http://localhost:8000/get_memorial?project=sentra_core"
 
 # Écrire un fichier dans le projet "sentra_core"
 curl -X POST http://localhost:8000/write_file \

--- a/scripts/api_sentra.py
+++ b/scripts/api_sentra.py
@@ -68,6 +68,7 @@ class RepriseResponse(BaseModel):
 
 class WriteNoteRequest(BaseModel):
     text: str
+    project: str = "sentra_core"
 
 class WriteFileRequest(BaseModel):
     project: str
@@ -203,6 +204,8 @@ async def write_note(req: WriteNoteRequest):
     if not text:
         raise HTTPException(status_code=400, detail="Le champ 'text' ne peut pas être vide.")
 
+    project_slug = req.project.strip().lower().replace(" ", "_") or "sentra_core"
+
     # 1) Chemin vers la racine du projet
     script_dir   = Path(__file__).resolve().parent   # …/scripts
     project_root = script_dir.parent                  # …/SENTRA_CORE_MEM_merged
@@ -235,7 +238,6 @@ async def write_note(req: WriteNoteRequest):
         raise HTTPException(status_code=500, detail=f"Échec d’écriture de la note : {repr(e)}")
 
     # 4) Journal mimétique Z_MEMORIAL.md
-    project_slug  = "sentra_core"
     memorial_dir  = project_root / "projects" / project_slug / "fichiers"
     memorial_dir.mkdir(parents=True, exist_ok=True)
     memorial_file = memorial_dir / "Z_MEMORIAL.md"
@@ -248,7 +250,7 @@ async def write_note(req: WriteNoteRequest):
         raise HTTPException(status_code=500, detail=f"Note ajoutée au JSON, mais échec du journal Markdown : {repr(e)}")
 
     try:
-        git_commit_push([memory_file, memorial_file], f"GPT note: {text[:50]}")
+        git_commit_push([memory_file, memorial_file], f"GPT note ({project_slug}): {text[:50]}")
     except RuntimeError as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -295,13 +297,13 @@ async def read_note(term: str = "", limit: int = 5):
 #  GET /get_memorial  (affichage de Z_MEMORIAL.md)
 # ------------------------------------
 @app.get("/get_memorial")
-async def get_memorial():
+async def get_memorial(project: str = "sentra_core"):
     """
-    Renvoie en texte brut le contenu de projects/SENTRA_CORE/fichiers/Z_MEMORIAL.md.
+    Renvoie en texte brut le contenu de projects/<projet>/fichiers/Z_MEMORIAL.md.
     """
     script_dir   = Path(__file__).resolve().parent   # …/scripts
     project_root = script_dir.parent                  # …/SENTRA_CORE_MEM_merged
-    project_slug = "sentra_core"
+    project_slug = project.strip().lower().replace(" ", "_") or "sentra_core"
     memorial_file = project_root / "projects" / project_slug / "fichiers" / "Z_MEMORIAL.md"
 
     if not memorial_file.exists():
@@ -342,7 +344,7 @@ async def write_file(req: WriteFileRequest):
         return WriteResponse(status="error", detail=f"Erreur écriture du fichier {file_path} : {e}")
 
     try:
-        git_commit_push([file_path], f"GPT file update: {filename}")
+        git_commit_push([file_path], f"GPT file update ({project_slug}): {filename}")
     except RuntimeError as e:
         return WriteResponse(status="error", detail=str(e))
 


### PR DESCRIPTION
## Summary
- let `/write_note` choose a project via `WriteNoteRequest.project`
- allow `project` query parameter on `/get_memorial`
- commit messages now include the project
- document project-specific calls in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d94540108331b8465fa979826010