### PR TITLE
Add /legal endpoint and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Un serveur *FastAPI* (voir `scripts/api_sentra.py`) expose plusieurs routes pour
 - `POST /write_file` – crée ou met à jour un fichier dans `projects/<projet>/fichiers/`
 - `POST /reprise` – résume un canal Discord
 - `GET /check_env` – vérifie la clé API (debug)
+- `GET /legal` – affiche la notice légale ou la licence du projet
 
 ### Exemples `curl`
 
@@ -199,6 +200,7 @@ Fournir une brique mémoire compressée, évolutive et 100% pilotable par agent 
 | /write_file    | POST    | Créer/éditer un fichier mémoire  |
 | /get_memorial  | GET     | Lire la mémoire (markdown)       |
 | /get_notes     | GET     | Lire tout le JSON mémoire        |
+| /legal         | GET     | Notice légale / licence          |
 | (à venir…)     | POST    | delete/move/orchestrate…         |
 
 ## Exemples d’utilisation

--- a/api_sentra.py
+++ b/api_sentra.py
@@ -55,6 +55,24 @@ async def check_env():
     return {"env_OK": True, "OPENAI_API_KEY_prefix": api_key[:6] + "..."}
 
 # ------------------------------------
+#  Notice légale / licence
+# ------------------------------------
+@app.get("/legal", include_in_schema=False)
+async def legal_notice():
+    """Retourne un court texte légal ou la licence du projet."""
+    notice_path = Path(__file__).parent.parent / "NOTICE.md"
+    if notice_path.exists():
+        try:
+            content = notice_path.read_text(encoding="utf-8")
+            return Response(content=content, media_type="text/markdown")
+        except Exception:
+            pass
+    return Response(
+        content="SENTRA Memory Plugin - MIT License \u00a9 2025 SENTRA CORE",
+        media_type="text/plain",
+    )
+
+# ------------------------------------
 #  Modèles de requête / réponse
 # ------------------------------------
 class RepriseRequest(BaseModel):

--- a/scripts/api_sentra.py
+++ b/scripts/api_sentra.py
@@ -55,6 +55,24 @@ async def check_env():
     return {"env_OK": True, "OPENAI_API_KEY_prefix": api_key[:6] + "..."}
 
 # ------------------------------------
+#  Notice légale / licence
+# ------------------------------------
+@app.get("/legal", include_in_schema=False)
+async def legal_notice():
+    """Retourne un court texte légal ou la licence du projet."""
+    notice_path = Path(__file__).parent.parent / "NOTICE.md"
+    if notice_path.exists():
+        try:
+            content = notice_path.read_text(encoding="utf-8")
+            return Response(content=content, media_type="text/markdown")
+        except Exception:
+            pass
+    return Response(
+        content="SENTRA Memory Plugin - MIT License \u00a9 2025 SENTRA CORE",
+        media_type="text/plain",
+    )
+
+# ------------------------------------
 #  Modèles de requête / réponse
 # ------------------------------------
 class RepriseRequest(BaseModel):


### PR DESCRIPTION
## Summary
- provide `/legal` endpoint with MIT license text
- document the new endpoint in README
- expose the license via FastAPI

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468bf3aa34833197db8405892b37a1