### PR TITLE
Add tests for FastAPI file operations

### DIFF
--- a/scripts/api_sentra.py
+++ b/scripts/api_sentra.py
@@ -85,6 +85,20 @@ class ReadNoteResponse(BaseModel):
     status: str
     results: list[str]
 
+# Requests pour la gestion de fichiers existants
+class DeleteFileRequest(BaseModel):
+    project: str
+    filename: str
+
+class MoveFileRequest(BaseModel):
+    project: str
+    src: str
+    dst: str
+
+class ArchiveFileRequest(BaseModel):
+    project: str
+    filename: str
+
 # ------------------------------------
 #  POST /reprise  (DISCORD → Résumé Brut → Résumé GPT)
 # ------------------------------------
@@ -369,3 +383,102 @@ async def write_file(req: WriteFileRequest):
         detail=f"Fichier créé/modifié : {file_path}",
         path=str(file_path)
     )
+
+# ------------------------------------
+#  POST /delete_file
+# ------------------------------------
+@app.post("/delete_file", response_model=WriteResponse)
+async def delete_file(req: DeleteFileRequest):
+    project = req.project.strip()
+    filename = req.filename.strip()
+    if not project or not filename:
+        raise HTTPException(status_code=400, detail="Les champs 'project' et 'filename' sont requis.")
+
+    base_path = Path(__file__).parent.parent
+    project_slug = project.lower().replace(" ", "_")
+    file_path = base_path / "projects" / project_slug / "fichiers" / filename
+
+    try:
+        file_path.unlink()
+    except FileNotFoundError:
+        return WriteResponse(status="error", detail=f"Fichier introuvable : {file_path}")
+    except PermissionError as e:
+        return WriteResponse(status="error", detail=f"Permission refusée : {e}")
+    except Exception as e:
+        return WriteResponse(status="error", detail=f"Erreur suppression du fichier {file_path} : {e}")
+
+    try:
+        git_commit_push([file_path], f"GPT delete ({project_slug}): {filename}")
+    except RuntimeError as e:
+        return WriteResponse(status="error", detail=str(e))
+
+    return WriteResponse(status="success", detail=f"Fichier supprimé : {file_path}", path=str(file_path))
+
+# ------------------------------------
+#  POST /move_file
+# ------------------------------------
+@app.post("/move_file", response_model=WriteResponse)
+async def move_file(req: MoveFileRequest):
+    project = req.project.strip()
+    src = req.src.strip()
+    dst = req.dst.strip()
+    if not project or not src or not dst:
+        raise HTTPException(status_code=400, detail="Les champs 'project', 'src' et 'dst' sont requis.")
+
+    base_path = Path(__file__).parent.parent
+    project_slug = project.lower().replace(" ", "_")
+    dossier = base_path / "projects" / project_slug / "fichiers"
+    src_path = dossier / src
+    dst_path = dossier / dst
+
+    try:
+        src_path.rename(dst_path)
+    except FileNotFoundError:
+        return WriteResponse(status="error", detail=f"Fichier source introuvable : {src_path}")
+    except PermissionError as e:
+        return WriteResponse(status="error", detail=f"Permission refusée : {e}")
+    except Exception as e:
+        return WriteResponse(status="error", detail=f"Erreur déplacement {src_path} -> {dst_path} : {e}")
+
+    try:
+        git_commit_push([src_path, dst_path], f"GPT move ({project_slug}): {src} -> {dst}")
+    except RuntimeError as e:
+        return WriteResponse(status="error", detail=str(e))
+
+    return WriteResponse(status="success", detail=f"Fichier déplacé : {dst_path}", path=str(dst_path))
+
+# ------------------------------------
+#  POST /archive_file
+# ------------------------------------
+@app.post("/archive_file", response_model=WriteResponse)
+async def archive_file(req: ArchiveFileRequest):
+    project = req.project.strip()
+    filename = req.filename.strip()
+    if not project or not filename:
+        raise HTTPException(status_code=400, detail="Les champs 'project' et 'filename' sont requis.")
+
+    base_path = Path(__file__).parent.parent
+    project_slug = project.lower().replace(" ", "_")
+    src_path = base_path / "projects" / project_slug / "fichiers" / filename
+    archive_dir = base_path / "archive" / project_slug
+    try:
+        archive_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        return WriteResponse(status="error", detail=f"Impossible de créer le dossier {archive_dir} : {e}")
+    dest_path = archive_dir / filename
+
+    try:
+        src_path.rename(dest_path)
+    except FileNotFoundError:
+        return WriteResponse(status="error", detail=f"Fichier introuvable : {src_path}")
+    except PermissionError as e:
+        return WriteResponse(status="error", detail=f"Permission refusée : {e}")
+    except Exception as e:
+        return WriteResponse(status="error", detail=f"Erreur archivage {src_path} : {e}")
+
+    try:
+        git_commit_push([src_path, dest_path], f"GPT archive ({project_slug}): {filename}")
+    except RuntimeError as e:
+        return WriteResponse(status="error", detail=str(e))
+
+    return WriteResponse(status="success", detail=f"Fichier archivé : {dest_path}", path=str(dest_path))

--- a/tests_api.py
+++ b/tests_api.py
@@ -1,0 +1,130 @@
+import json
+from pathlib import Path
+import pytest
+from fastapi.testclient import TestClient
+
+import scripts.api_sentra as api
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    dummy = tmp_path / "scripts" / "api_sentra.py"
+    dummy.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(api, "__file__", str(dummy))
+    monkeypatch.setattr(api, "git_commit_push", lambda *a, **k: None)
+    return TestClient(api.app)
+
+
+def test_write_note_success(client, tmp_path):
+    resp = client.post("/write_note", json={"text": "hello", "project": "demo"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    mem_file = tmp_path / "memory" / "sentra_memory.json"
+    assert mem_file.exists()
+    notes = json.loads(mem_file.read_text())
+    assert notes[-1]["text"] == "hello"
+    proj_file = tmp_path / "projects" / "demo" / "fichiers" / "memoire_demo.md"
+    assert proj_file.exists()
+
+
+def test_write_note_invalid(client):
+    resp = client.post("/write_note", json={"text": "   "})
+    assert resp.status_code == 400
+
+
+def test_write_note_permission_error(client, monkeypatch):
+    def fail(*args, **kwargs):
+        raise PermissionError("denied")
+    monkeypatch.setattr(Path, "write_text", fail)
+    resp = client.post("/write_note", json={"text": "x"})
+    assert resp.status_code == 500
+
+
+def test_write_file_success(client, tmp_path):
+    resp = client.post(
+        "/write_file",
+        json={"project": "demo", "filename": "a.txt", "content": "data"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    out = tmp_path / "projects" / "demo" / "fichiers" / "a.txt"
+    assert out.exists()
+
+
+def test_write_file_invalid(client):
+    resp = client.post("/write_file", json={"project": "", "filename": "f", "content": "x"})
+    assert resp.status_code == 400
+
+
+def test_write_file_permission_error(client, monkeypatch):
+    def fail(*args, **kwargs):
+        raise PermissionError("no")
+    monkeypatch.setattr(Path, "write_text", fail)
+    resp = client.post(
+        "/write_file",
+        json={"project": "demo", "filename": "x.txt", "content": "x"},
+    )
+    assert resp.json()["status"] == "error"
+
+
+def test_delete_file_success(client, tmp_path):
+    base = tmp_path / "projects" / "demo" / "fichiers"
+    base.mkdir(parents=True)
+    f = base / "t.txt"
+    f.write_text("ok")
+    resp = client.post("/delete_file", json={"project": "demo", "filename": "t.txt"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    assert not f.exists()
+
+
+def test_delete_file_not_found(client):
+    resp = client.post("/delete_file", json={"project": "demo", "filename": "no.txt"})
+    assert resp.json()["status"] == "error"
+
+
+def test_delete_file_invalid(client):
+    resp = client.post("/delete_file", json={"project": "", "filename": "f"})
+    assert resp.status_code == 400
+
+
+def test_move_file_success(client, tmp_path):
+    base = tmp_path / "projects" / "demo" / "fichiers"
+    base.mkdir(parents=True)
+    src = base / "src.txt"
+    src.write_text("data")
+    resp = client.post(
+        "/move_file",
+        json={"project": "demo", "src": "src.txt", "dst": "dst.txt"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    assert not src.exists()
+    assert (base / "dst.txt").exists()
+
+
+def test_move_file_invalid(client):
+    resp = client.post("/move_file", json={"project": "demo", "src": "a", "dst": ""})
+    assert resp.status_code == 400
+
+
+def test_archive_file_success(client, tmp_path):
+    base = tmp_path / "projects" / "demo" / "fichiers"
+    base.mkdir(parents=True)
+    src = base / "arch.txt"
+    src.write_text("data")
+    resp = client.post(
+        "/archive_file",
+        json={"project": "demo", "filename": "arch.txt"},
+    )
+    assert resp.status_code == 200
+    arc = tmp_path / "archive" / "demo" / "arch.txt"
+    assert resp.json()["status"] == "success"
+    assert arc.exists() and not src.exists()
+
+
+def test_archive_file_invalid(client):
+    resp = client.post("/archive_file", json={"project": "", "filename": "x"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- implement file management endpoints in FastAPI API
- cover `/write_note`, `/write_file` and new `/delete_file`, `/move_file`, `/archive_file` endpoints
- add pytest suite for API routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468bf5ea8083318be3780077973d9d