### PR TITLE
Remove stray main file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ memory/abbr_dict.json
 memory/alphanum_dict.json
 memory/custom_dict.json
 obfuscated_map.json
+main


### PR DESCRIPTION
## Summary
- delete zero-byte `main`
- ignore it in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx'; IndentationError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6846fa3d00fc8331bd26b9096624742c