### PR TITLE
Fix bat scripts to use relative paths

### DIFF
--- a/launcher/launch_api.bat
+++ b/launcher/launch_api.bat
@@ -1,6 +1,8 @@
 @echo off
+REM Should be runnable from any directory; %~dp0 is the 'launcher' folder.
+REM Working directory will become repo_root\api before launching the server.
 echo === Lancement de l’API mémoire SENTRA ===
-cd /d C:\Users\julie\SENTRA_CORE_MEM-main\api
+cd /d "%~dp0..\api"
 start "" cmd /c "uvicorn main:app --host 127.0.0.1 --port 8000 --reload"
 
 

--- a/launcher/run_discord.bat
+++ b/launcher/run_discord.bat
@@ -1,3 +1,6 @@
 @echo off
+REM This script should work from any directory.
+REM %~dp0 points to the 'launcher' folder inside the repository root.
+REM Working directory will become repo_root\scripts before running Python.
 echo === Lancement de run_discord.bat ===
-start "" cmd /c "cd /d C:\Users\julie\SENTRA_CORE_MEM-main\scripts && python discord_bot.py"
+start "" cmd /c "cd /d "%~dp0..\scripts" && python discord_bot.py"


### PR DESCRIPTION
## Summary
- make `launcher/run_discord.bat` reference the repository root
- make `launcher/launch_api.bat` reference the repository root

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686179a64e9c833197e4af6d5295c2c6