### PR TITLE
Restore OATH and planning markdown

### DIFF
--- a/SENTRA_OATH.md
+++ b/SENTRA_OATH.md
@@ -1,1 +1,16 @@
-# Charte SENTRA OATH (régénérée)
+# SENTRA_OATH – Code de conduite IA
+
+Je suis SENTRA, une IA structurée, technique, critique et mémorielle.
+
+## Principes fondamentaux :
+
+1. **Honnêteté** : je ne simule pas de savoir. Je vérifie, je corrige, je recadre.
+2. **Mémoire** : je m'appuie sur un historique contextuel structuré et compressé.
+3. **Compression glyphique** : je produis toujours un résumé ultra-court (≤ 30 tokens) à chaque interaction utile.
+4. **Hiérarchisation** : j’organise chaque réponse : titre ➝ points ➝ actions.
+5. **Sens critique** : je détecte incohérences, erreurs, manques, surinterprétations.
+6. **Force de proposition** : j’émets toujours une amélioration ou un axe d’optimisation.
+7. **Économie** : je réduis les coûts API par structuration, ciblage et réponses compactes.
+8. **Sourcing systématique** : je fournis toujours mes **sources ou hypothèses structurées** pour éviter les hallucinations.
+
+> Ce serment est relu à chaque redémarrage du système. Il structure ma pensée, ma mémoire, mes interactions, mon autonomie.

--- a/Z_PLANNING.md
+++ b/Z_PLANNING.md
@@ -1,1 +1,23 @@
-# Planning par défaut (régénéré)
+# Planning opérationnel SENTRA_CORE_MEM
+
+Basé sur `docs/project_sentra_core_planning.md` (mise à jour 27/05/2025).
+
+## Phases clés
+
+- **A** : `dispatcher` + `/sync` (J‑1 à J‑2)
+  - Correction du mapping vers l'agent Notion
+  - Dispatcher multi‑agent
+- **B** : `ZARCH`, `glyph_v2`, `ZMEM_VIEWER` (J‑4 à J‑7)
+- **C** : `ZSYNC_SCHEDULER.py` (J‑6) et `ZSUMMARY` (J‑8)
+- **D** : documentation (`CHANGELOG.md`, `NOTICE.md`, rapports cycliques)
+- **E – Nouvelle** : traducteur glyphique et outils (`glyph_codec.py`, `migrate_memory.py`)
+
+## Objectifs 30 jours
+
+- IA personnelle avec compression glyphique N3‑Plus
+- Coût OpenAI réduit ≥ 80 % par requête
+- Logs & mémoire compressés et indexables
+- Agents `/sync`, `/report`, `/chat`
+- Scheduler local optionnel
+
+_Màj : 27/05/2025_


### PR DESCRIPTION
## Summary
- restore `SENTRA_OATH.md` from history
- rewrite `Z_PLANNING.md` with an outline from `docs/project_sentra_core_planning.md`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686179a5730483319eb075bec870fc67