### PR TITLE
Validate filenames and unify write paths

### DIFF
--- a/scripts/api_sentra.py
+++ b/scripts/api_sentra.py
@@ -380,16 +380,16 @@ async def write_file(req: WriteFileRequest):
     if not projet or not filename:
         raise HTTPException(status_code=400, detail="Les champs 'project' et 'filename' sont requis.")
 
-    base_path        = Path(__file__).parent.parent
-    project_slug     = projet.lower().replace(" ", "_")
-    dossier_fichiers = base_path / "projects" / project_slug / "fichiers"
+    if ".." in filename:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    project_slug = projet.lower().replace(" ", "_")
+    file_path = BASE_DIR / "projects" / project_slug / "fichiers" / filename
 
     try:
-        dossier_fichiers.mkdir(parents=True, exist_ok=True)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
     except Exception as e:
-        return WriteResponse(status="error", detail=f"Impossible de créer le dossier {dossier_fichiers} : {e}")
-
-    file_path = dossier_fichiers / filename
+        return WriteResponse(status="error", detail=f"Impossible de créer le dossier {file_path.parent} : {e}")
     try:
         file_path.write_text(contenu, encoding="utf-8")
     except Exception as e:

--- a/scripts/tests_api.py
+++ b/scripts/tests_api.py
@@ -12,6 +12,7 @@ def client(tmp_path, monkeypatch):
     dummy = tmp_path / "scripts" / "api_sentra.py"
     dummy.parent.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(api, "__file__", str(dummy))
+    monkeypatch.setattr(api, "BASE_DIR", tmp_path)
     monkeypatch.setattr(api, "git_commit_push", lambda *a, **k: None)
     return TestClient(api.app)
 


### PR DESCRIPTION
## Summary
- validate filenames to prevent path traversal
- use `BASE_DIR` when building the path in `/write_file`
- adjust tests to patch `BASE_DIR`

## Testing
- `pytest scripts/tests_api.py -k write_file -q` *(fails: IndentationError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6864c4c1e3fc833183be6d3d90c3607d