### PR TITLE
Harmonize responses for file listing and search

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -198,7 +198,7 @@ HEAD
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {"$ref": "#/components/schemas/ListFilesResponse"}
               }
             }
           },
@@ -397,7 +397,7 @@ HEAD
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {"$ref": "#/components/schemas/SearchResponse"}
               }
             }
           },
@@ -745,6 +745,40 @@ HEAD
               { "type": "null" }
             ],
             "title": "Path"
+          }
+        }
+      },
+      "ListFilesResponse": {
+        "type": "object",
+        "title": "ListFilesResponse",
+        "required": ["status", "files"],
+        "properties": {
+          "status": {"type": "string", "title": "Status"},
+          "detail": {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "title": "Detail"
+          },
+          "files": {
+            "type": "array",
+            "title": "Files",
+            "items": {"type": "string"}
+          }
+        }
+      },
+      "SearchResponse": {
+        "type": "object",
+        "title": "SearchResponse",
+        "required": ["status", "matches"],
+        "properties": {
+          "status": {"type": "string", "title": "Status"},
+          "detail": {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "title": "Detail"
+          },
+          "matches": {
+            "type": "array",
+            "title": "Matches",
+            "items": {"type": "string"}
           }
         }
       }

--- a/scripts/api_sentra.py
+++ b/scripts/api_sentra.py
@@ -119,6 +119,16 @@ class ReadNoteResponse(BaseModel):
     status: str
     results: list[str]
 
+class ListFilesResponse(BaseModel):
+    status: str
+    detail: str | None = None
+    files: list[str]
+
+class SearchResponse(BaseModel):
+    status: str
+    detail: str | None = None
+    matches: list[str]
+
 # Requests pour la gestion de fichiers existants
 
 # ------------------------------------
@@ -486,16 +496,23 @@ async def archive_file(req: ArchiveFileRequest):
 # ------------------------------------
 #  GET /list_files
 # ------------------------------------
-@app.get("/list_files")
+@app.get("/list_files", response_model=ListFilesResponse)
 async def list_files(dir: str, pattern: str = "*"):
     p = Path(dir)
-    files = [str(f) for f in p.glob(pattern)]
-    return {"files": files}
+    try:
+        files = [str(f) for f in p.glob(pattern)]
+        return ListFilesResponse(
+            status="success",
+            detail=f"{len(files)} file(s) found",
+            files=files,
+        )
+    except Exception as e:
+        return ListFilesResponse(status="error", detail=str(e), files=[])
 
 # ------------------------------------
 #  GET /search
 # ------------------------------------
-@app.get("/search")
+@app.get("/search", response_model=SearchResponse)
 async def search_files(term: str, dir: str):
     base = Path(dir)
     results = []
@@ -506,7 +523,11 @@ async def search_files(term: str, dir: str):
                     results.append(str(f))
             except Exception:
                 continue
-    return {"matches": results}
+    return SearchResponse(
+        status="success",
+        detail=f"{len(results)} match(es)",
+        matches=results,
+    )
 
 # === SENTRA CORE MEM — ROUTES PUBLIQUES INTELLIGENTES ===
 


### PR DESCRIPTION
## Summary
- add Pydantic models for listing and search routes
- return `status` and `detail` from `/list_files` and `/search`
- document new models in `openapi.json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6864c4c0afdc83319babe83fc7d0a6bf