### PR TITLE
Add pytest suite for filesystem and memory routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,5 +374,15 @@ Rédaction README audit	15 min
 
 © 2025 — Projet open‑source modulable ✨
 
+## ✅ Tests automatisés
+
+Le paquet `tests/` contient une suite Pytest couvrant les routes mémoire/fichiers et un scénario E2E (marqué `slow`). Les fixtures isolent les dépendances externes (Git, Google Sheet, n8n, Discord) en les simulant.
+
+```bash
+pytest
+```
+
+Utilisez `pytest -m "not slow"` pour exclure le test de bout en bout si besoin.
+
 ## Licence
 Ce projet est distribué sous licence MIT. Voir le fichier [LICENSE](LICENSE) pour plus d'informations.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+markers =
+    slow: End-to-end workflow exercising multiple subsystems

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.routes.correction as correction
+import scripts.api_sentra as api
+
+
+@pytest.fixture
+def api_context(tmp_path, monkeypatch):
+    base_dir = tmp_path / "sentra"
+    for sub in ("projects", "memory", "logs", "archive"):
+        (base_dir / sub).mkdir(parents=True, exist_ok=True)
+
+    commits: list[dict[str, object]] = []
+
+    def fake_git_commit_push(paths, message):
+        normalized = [Path(p) for p in paths]
+        commits.append({"paths": normalized, "message": message})
+
+    monkeypatch.setattr(api, "git_commit_push", fake_git_commit_push)
+
+    def fake_search_memory(term: str, max_results: int = 5):
+        mem_file = base_dir / "memory" / "sentra_memory.json"
+        if not mem_file.exists():
+            return []
+        data = json.loads(mem_file.read_text(encoding="utf-8"))
+        results: list[str] = []
+        for entry in data:
+            if term.lower() in entry.get("text", "").lower():
+                ts = entry.get("timestamp", "now")
+                results.append(f"- [{ts}] {entry['text']}")
+            if len(results) >= max_results:
+                break
+        return results
+
+    monkeypatch.setattr(api, "search_memory", fake_search_memory)
+
+    def fake_query_memory(limit: int):
+        mem_file = base_dir / "memory" / "sentra_memory.json"
+        if not mem_file.exists():
+            return []
+        data = json.loads(mem_file.read_text(encoding="utf-8"))
+        return data[-limit:]
+
+    monkeypatch.setattr(api, "query_memory", fake_query_memory)
+
+    monkeypatch.setattr(api, "BASE_DIR", base_dir)
+
+    sandbox_root = (base_dir / "sandbox" / "SENTRA_SANDBOX").resolve()
+    sandbox_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(correction, "ALLOWED_BASE_DIR", str(sandbox_root))
+
+    return {"base_dir": base_dir, "commits": commits, "sandbox": sandbox_root}
+
+
+@pytest.fixture
+def client(api_context):
+    with TestClient(api.app) as test_client:
+        yield test_client

--- a/tests/test_e2e_workflow.py
+++ b/tests/test_e2e_workflow.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.slow
+def test_full_workflow_through_filesystem_and_memory(client, api_context):
+    base_dir = api_context["base_dir"]
+
+    note_text = "Organizer hands-off spec to CodeXpert"
+    note_response = client.post(
+        "/write_note",
+        json={"text": note_text, "project": "demo"},
+    )
+    assert note_response.status_code == 200
+
+    spec_body = "Initial spec drafted for CodeXpert"
+    create_response = client.post(
+        "/write_file",
+        json={"project": "demo", "filename": "handoff/spec.md", "content": spec_body},
+    )
+    assert create_response.status_code == 200
+    handoff_path = Path(create_response.json()["path"])
+    assert handoff_path.exists()
+
+    move_response = client.post(
+        "/move_file",
+        json={
+            "src": "projects/demo/fichiers/handoff/spec.md",
+            "dst": "projects/demo/fichiers/review/spec.md",
+        },
+    )
+    assert move_response.status_code == 200
+    assert move_response.json()["status"] == "success"
+
+    archive_response = client.post(
+        "/archive_file",
+        json={
+            "path": "projects/demo/fichiers/review/spec.md",
+            "archive_dir": "archive/demo",
+        },
+    )
+    assert archive_response.status_code == 200
+    assert archive_response.json()["status"] == "success"
+
+    read_response = client.get("/read_note", params={"term": "hands-off"})
+    assert read_response.status_code == 200
+    data = read_response.json()
+    assert data["status"] == "success"
+    combined = " ".join(data["results"]).lower()
+    assert "organizer hands-off" in combined
+
+    search_response = client.get(
+        "/search",
+        params={"term": "Initial spec", "dir": "archive/demo"},
+    )
+    assert search_response.status_code == 200
+    archived_path = base_dir / "archive" / "demo" / "spec.md"
+    assert str(archived_path) in search_response.json()["matches"]
+
+    memorial_response = client.get("/get_memorial", params={"project": "demo"})
+    assert memorial_response.status_code == 200
+    assert "Organizer hands-off" in memorial_response.text
+
+    commit_messages = [entry["message"] for entry in api_context["commits"]]
+    assert any("GPT note" in message for message in commit_messages)
+    assert any("GPT file update" in message for message in commit_messages)
+    assert any("GPT move" in message for message in commit_messages)
+    assert any("GPT archive" in message for message in commit_messages)

--- a/tests/test_filesystem_router.py
+++ b/tests/test_filesystem_router.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_write_file_success(client, api_context):
+    response = client.post(
+        "/write_file",
+        json={"project": "Demo", "filename": "notes/spec.md", "content": "# Spec"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    written_path = Path(data["path"])
+    expected_path = api_context["base_dir"] / "projects" / "demo" / "fichiers" / "notes" / "spec.md"
+    assert written_path == expected_path
+    assert written_path.read_text(encoding="utf-8") == "# Spec"
+    assert any("GPT file update" in entry["message"] for entry in api_context["commits"])
+
+
+def test_write_file_validation_errors(client):
+    response = client.post(
+        "/write_file",
+        json={"project": "demo", "filename": " ", "content": "data"},
+    )
+    assert response.status_code == 400
+
+
+def test_write_file_rejects_escape(client):
+    response = client.post(
+        "/write_file",
+        json={"project": "demo", "filename": "../escape.md", "content": "no"},
+    )
+    assert response.status_code == 400
+
+
+def test_move_file_success(client, api_context):
+    base_dir = api_context["base_dir"]
+    src_rel = Path("projects/demo/fichiers/spec.txt")
+    dst_rel = Path("projects/demo/fichiers/spec-final.txt")
+    src_path = base_dir / src_rel
+    src_path.parent.mkdir(parents=True, exist_ok=True)
+    src_path.write_text("content", encoding="utf-8")
+
+    response = client.post("/move_file", json={"src": str(src_rel), "dst": str(dst_rel)})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "success"
+    assert not src_path.exists()
+    assert (base_dir / dst_rel).exists()
+    assert any("GPT move" in entry["message"] for entry in api_context["commits"])
+
+
+def test_move_file_missing_source(client):
+    response = client.post(
+        "/move_file",
+        json={
+            "src": "projects/demo/fichiers/missing.txt",
+            "dst": "projects/demo/fichiers/new-name.txt",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "error"
+    assert "introuvable" in data["detail"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"src": " ", "dst": "projects/demo/fichiers/out.txt"},
+        {"src": "projects/demo/fichiers/in.txt", "dst": ""},
+    ],
+)
+def test_move_file_validation(payload, client):
+    response = client.post("/move_file", json=payload)
+    assert response.status_code == 400
+
+
+def test_archive_file_success(client, api_context):
+    base_dir = api_context["base_dir"]
+    src_rel = Path("projects/demo/fichiers/archive.txt")
+    archive_rel = Path("archive/demo")
+    src_path = base_dir / src_rel
+    src_path.parent.mkdir(parents=True, exist_ok=True)
+    src_path.write_text("archive me", encoding="utf-8")
+
+    response = client.post(
+        "/archive_file",
+        json={"path": str(src_rel), "archive_dir": str(archive_rel)},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    dest_path = base_dir / archive_rel / src_path.name
+    assert dest_path.exists() and not src_path.exists()
+    assert any("GPT archive" in entry["message"] for entry in api_context["commits"])
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"path": " ", "archive_dir": "archive/demo"},
+        {"path": "projects/demo/fichiers/file.txt", "archive_dir": "../escape"},
+    ],
+)
+def test_archive_file_validation(client, payload):
+    response = client.post("/archive_file", json=payload)
+    assert response.status_code == 400
+
+
+def test_delete_file_success(client, api_context):
+    base_dir = api_context["base_dir"]
+    file_rel = Path("projects/demo/fichiers/remove.txt")
+    target = base_dir / file_rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("bye", encoding="utf-8")
+
+    response = client.post("/delete_file", json={"path": str(file_rel)})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "success"
+    assert not target.exists()
+    assert any("GPT delete" in entry["message"] for entry in api_context["commits"])
+
+
+def test_delete_file_missing(client):
+    response = client.post(
+        "/delete_file",
+        json={"path": "projects/demo/fichiers/ghost.txt"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "error"
+    assert "introuvable" in data["detail"]
+
+
+def test_delete_file_validation(client):
+    response = client.post("/delete_file", json={"path": " "})
+    assert response.status_code == 400
+
+
+def test_list_files_returns_matches(client, api_context):
+    base_dir = api_context["base_dir"]
+    project_dir = base_dir / "projects" / "demo" / "fichiers"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "a.md").write_text("A", encoding="utf-8")
+    (project_dir / "b.txt").write_text("B", encoding="utf-8")
+
+    response = client.get(
+        "/list_files",
+        params={"dir": "projects/demo/fichiers", "pattern": "*.md"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert str(project_dir / "a.md") in data["files"]
+    assert str(project_dir / "b.txt") not in data["files"]
+
+
+def test_search_files(client, api_context):
+    base_dir = api_context["base_dir"]
+    project_dir = base_dir / "projects" / "demo" / "fichiers"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "spec.md").write_text("Important spec for SENTRA", encoding="utf-8")
+
+    response = client.get(
+        "/search",
+        params={"term": "spec", "dir": "projects/demo/fichiers"},
+    )
+    assert response.status_code == 200
+    results = response.json()
+    assert results["matches"]
+    assert str(project_dir / "spec.md") in results["matches"]
+
+
+def test_search_files_missing_directory(client):
+    response = client.get(
+        "/search",
+        params={"term": "x", "dir": "projects/demo/missing"},
+    )
+    assert response.status_code == 404
+
+
+def test_explore_prevents_escape(client):
+    response = client.get(
+        "/explore",
+        params={"project": "demo", "path": "../../etc"},
+    )
+    assert response.status_code == 400
+
+
+def test_explore_lists_files(client, api_context):
+    base_dir = api_context["base_dir"]
+    root = base_dir / "projects" / "demo"
+    nested = root / "fichiers"
+    nested.mkdir(parents=True, exist_ok=True)
+    (nested / "index.md").write_text("content", encoding="utf-8")
+
+    response = client.get(
+        "/explore",
+        params={"project": "demo", "path": "/"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["children"]
+    assert any(item["name"] == "fichiers" for item in payload["children"])

--- a/tests/test_memory_router.py
+++ b/tests/test_memory_router.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_write_note_persists_and_logs(client, api_context):
+    response = client.post(
+        "/write_note",
+        json={"text": "Capture meeting notes", "project": "Demo"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "success"
+
+    base_dir = api_context["base_dir"]
+    mem_file = base_dir / "memory" / "sentra_memory.json"
+    assert mem_file.exists()
+    entries = json.loads(mem_file.read_text(encoding="utf-8"))
+    assert entries[-1]["text"] == "Capture meeting notes"
+
+    memorial = base_dir / "projects" / "demo" / "fichiers" / "Z_MEMORIAL.md"
+    assert memorial.exists()
+    memorial_content = memorial.read_text(encoding="utf-8")
+    assert "Capture meeting notes" in memorial_content
+
+    assert any("GPT note" in entry["message"] for entry in api_context["commits"])
+
+
+def test_write_note_requires_non_empty_text(client):
+    response = client.post("/write_note", json={"text": "  "})
+    assert response.status_code == 400
+
+
+def test_get_memorial_returns_placeholder(client):
+    response = client.get("/get_memorial", params={"project": "demo"})
+    assert response.status_code == 200
+    assert "Z_MEMORIAL.md non trouvé" in response.text
+
+
+def test_get_memorial_serves_content(client, api_context):
+    base_dir = api_context["base_dir"]
+    memorial = base_dir / "projects" / "demo" / "fichiers" / "Z_MEMORIAL.md"
+    memorial.parent.mkdir(parents=True, exist_ok=True)
+    memorial.write_text("## Log\n- entry", encoding="utf-8")
+
+    response = client.get("/get_memorial", params={"project": "demo"})
+    assert response.status_code == 200
+    assert response.text.strip().startswith("## Log")
+
+
+def test_read_note_from_filepath(client, api_context):
+    base_dir = api_context["base_dir"]
+    note_path = base_dir / "projects" / "demo" / "fichiers" / "notes.md"
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text("direct note content", encoding="utf-8")
+
+    response = client.get("/read_note", params={"filepath": "projects/demo/fichiers/notes.md"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert "direct note content" in data["results"][0]
+
+
+def test_read_note_missing_filepath_returns_error(client):
+    response = client.get(
+        "/read_note",
+        params={"filepath": "projects/demo/fichiers/missing.md"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "error"
+    assert "introuvable" in data["results"][0]
+
+
+def test_read_note_uses_memory_search(client, api_context):
+    client.post("/write_note", json={"text": "Planifier sprint demo", "project": "Demo"})
+
+    response = client.get("/read_note", params={"term": "sprint"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert any("Planifier sprint demo" in line for line in data["results"])
+
+
+def test_read_note_no_results(client):
+    response = client.get("/read_note", params={"term": "absent"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "error"
+    assert "Aucune note" in data["results"][0]
+
+
+def test_read_note_invalid_filepath(client):
+    response = client.get("/read_note", params={"filepath": "  "})
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- add a dedicated `tests/` package with pytest fixtures that sandbox filesystem/git operations for the FastAPI app
- add unit coverage for the filesystem and memory endpoints plus a slow end-to-end workflow scenario
- document the new test suite and how to run it via `pytest`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68cd9e24a3cc8331b54587e7a65e5096