### PR TITLE
Refactor FastAPI app into modular tool routers

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from app.services.audit import AuditLogger
+from app.services.git_ops import GitOpsHelper
+from app.services.memory_store import MemoryStore
+from app.services.n8n_client import N8NClient
+from app.services.google_clients import GoogleAuthManager
+from app.services.bus_service import BusService
+from app.services.rag_service import RAGService
+from app.services.paths import BASE_DIR
+
+
+@lru_cache(maxsize=1)
+def get_audit_logger() -> AuditLogger:
+    log_path = BASE_DIR / "logs" / "audit.log"
+    return AuditLogger(log_path=log_path)
+
+
+@lru_cache(maxsize=1)
+def get_git_helper() -> GitOpsHelper:
+    return GitOpsHelper(repo_root=BASE_DIR)
+
+
+@lru_cache(maxsize=1)
+def get_memory_store() -> MemoryStore:
+    memory_dir = BASE_DIR / "memory"
+    return MemoryStore(memory_dir)
+
+
+@lru_cache(maxsize=1)
+def get_n8n_client() -> N8NClient:
+    return N8NClient()
+
+
+@lru_cache(maxsize=1)
+def get_google_auth_manager() -> GoogleAuthManager:
+    return GoogleAuthManager()
+
+
+@lru_cache(maxsize=1)
+def get_bus_service() -> BusService:
+    return BusService(auth_manager=get_google_auth_manager())
+
+
+@lru_cache(maxsize=1)
+def get_rag_service() -> RAGService:
+    rag_dir = BASE_DIR / "memory" / "chroma"
+    return RAGService(persist_directory=rag_dir)

--- a/app/main.py
+++ b/app/main.py
@@ -1,36 +1,34 @@
-from fastapi import FastAPI, HTTPException, Query
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.routes.bus import router as bus_router
 from app.routes.correction import router as correction_router
-from scripts.memory_zep_local import save_to_zep, search_zep
-from pydantic import BaseModel
+from app.routes.files import router as files_router
+from app.routes.google import router as google_router
+from app.routes.memory import router as memory_router
+from app.routes.n8n import router as n8n_router
+from app.routes.rag import router as rag_router
+from app.routes.zep import router as zep_router
 
-app = FastAPI()
 
-@app.get("/")
-def read_root():
-    return {"status": "ok", "message": "SENTRA API active"}
+def create_app() -> FastAPI:
+    app = FastAPI(title="SENTRA API", version="1.0.0")
 
-# Route correction
-app.include_router(correction_router)
+    @app.get("/")
+    def health_check() -> dict[str, str]:
+        return {"status": "ok", "message": "SENTRA API active"}
 
-# === ROUTES ZEP ===
+    app.include_router(files_router)
+    app.include_router(memory_router)
+    app.include_router(n8n_router)
+    app.include_router(google_router)
+    app.include_router(bus_router)
+    app.include_router(rag_router)
+    app.include_router(correction_router)
+    app.include_router(zep_router)
 
-class ZepPayload(BaseModel):
-    session_id: str
-    role: str
-    content: str
+    return app
 
-@app.post("/zep/save")
-def api_zep_save(payload: ZepPayload):
-    try:
-        res = save_to_zep(payload.session_id, payload.role, payload.content)
-        return {"status": "ok", "zep_response": res.json()}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/zep/search")
-def api_zep_search(session_id: str = Query(...), query: str = Query(...)):
-    try:
-        results = search_zep(session_id, query)
-        return {"status": "ok", "results": results}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+app = create_app()

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,1 @@
+# Routers are exposed via explicit imports in app.main.

--- a/app/routes/bus.py
+++ b/app/routes/bus.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.dependencies import get_audit_logger, get_bus_service
+from app.services.audit import AuditLogger
+from app.services.bus_service import BusService, BusServiceError
+
+router = APIRouter(tags=["bus"])
+
+
+class BusSendRequest(BaseModel):
+    user: str = Field(..., min_length=1)
+    agent: str = Field(..., min_length=1)
+    spreadsheet_id: str = Field(..., min_length=1)
+    worksheet: str = Field(..., min_length=1)
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str | None = None
+
+
+class BusSendResponse(BaseModel):
+    message_id: str
+    status: str
+    timestamp: str
+
+
+class BusPollRequest(BaseModel):
+    user: str = Field(..., min_length=1)
+    spreadsheet_id: str = Field(..., min_length=1)
+    worksheet: str = Field(..., min_length=1)
+    status: str | None = None
+    limit: int = Field(20, ge=1, le=100)
+
+
+class BusRecord(BaseModel):
+    message_id: str
+    timestamp: str
+    user: str
+    agent: str
+    status: str
+    payload: Dict[str, Any]
+
+
+class BusPollResponse(BaseModel):
+    records: List[BusRecord]
+
+
+class BusUpdateStatusRequest(BaseModel):
+    user: str = Field(..., min_length=1)
+    agent: str = Field(..., min_length=1)
+    spreadsheet_id: str = Field(..., min_length=1)
+    worksheet: str = Field(..., min_length=1)
+    message_id: str = Field(..., min_length=1)
+    status: str = Field(..., min_length=1)
+
+
+class BusUpdateStatusResponse(BaseModel):
+    message_id: str
+    status: str
+
+
+@router.post("/bus/send", name="bus.send")
+def bus_send(
+    request: BusSendRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    service: BusService = Depends(get_bus_service),
+) -> BusSendResponse:
+    audit_logger.log("bus.send", request.model_dump(exclude={"user"}), request.user)
+    try:
+        result = service.send(
+            spreadsheet_id=request.spreadsheet_id,
+            worksheet=request.worksheet,
+            payload=request.payload,
+            user=request.user,
+            agent=request.agent,
+            idempotency_key=request.idempotency_key,
+        )
+    except BusServiceError as error:
+        raise HTTPException(status_code=502, detail=str(error)) from error
+    return BusSendResponse(**result)
+
+
+@router.post("/bus/poll", name="bus.poll")
+def bus_poll(
+    request: BusPollRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    service: BusService = Depends(get_bus_service),
+) -> BusPollResponse:
+    audit_logger.log("bus.poll", request.model_dump(exclude={"user"}), request.user)
+    try:
+        records = service.poll(
+            spreadsheet_id=request.spreadsheet_id,
+            worksheet=request.worksheet,
+            status=request.status,
+            limit=request.limit,
+        )
+    except BusServiceError as error:
+        raise HTTPException(status_code=502, detail=str(error)) from error
+    return BusPollResponse(records=[BusRecord(**record) for record in records])
+
+
+@router.post("/bus/updateStatus", name="bus.updateStatus")
+def bus_update_status(
+    request: BusUpdateStatusRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    service: BusService = Depends(get_bus_service),
+) -> BusUpdateStatusResponse:
+    audit_logger.log("bus.updateStatus", request.model_dump(exclude={"user"}), request.user)
+    try:
+        result = service.update_status(
+            spreadsheet_id=request.spreadsheet_id,
+            worksheet=request.worksheet,
+            message_id=request.message_id,
+            status=request.status,
+        )
+    except BusServiceError as error:
+        raise HTTPException(status_code=502, detail=str(error)) from error
+    return BusUpdateStatusResponse(**result)

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from datetime import datetime
+from hashlib import sha256
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.dependencies import get_audit_logger, get_git_helper
+from app.services.audit import AuditLogger
+from app.services.git_ops import GitOpsError, GitOpsHelper
+from app.services.paths import resolve_workspace_path
+
+router = APIRouter(tags=["files"])
+
+
+class FileReadRequest(BaseModel):
+    path: str = Field(..., description="Path beginning with /projects, /reports, or /students")
+    user: str = Field(..., min_length=1)
+
+
+class FileReadResponse(BaseModel):
+    path: str
+    content: str
+    sha256: str
+    last_modified: datetime | None
+
+
+class FileWriteRequest(FileReadRequest):
+    content: str = Field(..., description="File contents to persist")
+    agent: str = Field(..., min_length=1)
+    idempotency_key: str | None = Field(None, description="Caller-supplied idempotency key")
+
+
+class FileWriteResponse(BaseModel):
+    path: str
+    sha256: str
+    committed: bool
+    commit_message: str | None
+
+
+@router.post("/files/read", name="files.read")
+def read_file(request: FileReadRequest, audit_logger: AuditLogger = Depends(get_audit_logger)) -> FileReadResponse:
+    audit_logger.log("files.read", request.model_dump(exclude={"user"}), request.user)
+    try:
+        target_path = resolve_workspace_path(request.path)
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    if not target_path.exists() or not target_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    content = target_path.read_text(encoding="utf-8")
+    digest = sha256(content.encode("utf-8")).hexdigest()
+    stat = target_path.stat()
+    last_modified = datetime.fromtimestamp(stat.st_mtime)
+    return FileReadResponse(
+        path=str(target_path),
+        content=content,
+        sha256=digest,
+        last_modified=last_modified,
+    )
+
+
+@router.post("/files/write", name="files.write")
+def write_file(
+    request: FileWriteRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    git_helper: GitOpsHelper = Depends(get_git_helper),
+) -> FileWriteResponse:
+    audit_logger.log("files.write", request.model_dump(exclude={"user"}), request.user)
+    try:
+        target_path = resolve_workspace_path(request.path)
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    existing_content = target_path.read_text(encoding="utf-8") if target_path.exists() else None
+    if existing_content == request.content:
+        digest = sha256(request.content.encode("utf-8")).hexdigest()
+        return FileWriteResponse(
+            path=str(target_path),
+            sha256=digest,
+            committed=False,
+            commit_message=None,
+        )
+    target_path.write_text(request.content, encoding="utf-8")
+    digest = sha256(request.content.encode("utf-8")).hexdigest()
+    try:
+        commit_message = git_helper.commit_and_push("files.write", target_path, request.agent, digest)
+    except GitOpsError as error:
+        raise HTTPException(status_code=500, detail=str(error)) from error
+    return FileWriteResponse(
+        path=str(target_path),
+        sha256=digest,
+        committed=commit_message is not None,
+        commit_message=commit_message,
+    )

--- a/app/routes/google.py
+++ b/app/routes/google.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import base64
+import binascii
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException
+from googleapiclient.errors import HttpError
+from pydantic import BaseModel, Field
+
+from app.dependencies import get_audit_logger, get_google_auth_manager
+from app.services.audit import AuditLogger
+from app.services.google_clients import GoogleAuthManager, GoogleCredentialsError
+
+router = APIRouter(tags=["google"])
+
+
+def _ensure_timezone(value: datetime, fallback: str | None) -> Dict[str, str]:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return {
+        "dateTime": value.isoformat(),
+        "timeZone": fallback or value.tzinfo.tzname(value) or "UTC",
+    }
+
+
+class GCalCreateEventRequest(BaseModel):
+    user: str = Field(..., min_length=1)
+    agent: str = Field(..., min_length=1)
+    calendar_id: str = Field(..., min_length=1)
+    summary: str = Field(..., min_length=1)
+    description: str | None = None
+    location: str | None = None
+    start: datetime
+    end: datetime
+    timezone: str | None = Field(default=None)
+    attendees: List[str] = Field(default_factory=list)
+    idempotency_key: str | None = None
+
+
+class GCalCreateEventResponse(BaseModel):
+    event_id: str
+    html_link: str | None
+    status: str
+
+
+@router.post("/google/gcal/create_event", name="gcal.create_event")
+def create_gcal_event(
+    request: GCalCreateEventRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    auth_manager: GoogleAuthManager = Depends(get_google_auth_manager),
+) -> GCalCreateEventResponse:
+    audit_logger.log("gcal.create_event", request.model_dump(exclude={"user"}), request.user)
+    try:
+        service = auth_manager.calendar_service()
+    except GoogleCredentialsError as error:
+        raise HTTPException(status_code=500, detail=str(error)) from error
+    event_body: Dict[str, Any] = {
+        "summary": request.summary,
+        "description": request.description,
+        "location": request.location,
+        "start": _ensure_timezone(request.start, request.timezone),
+        "end": _ensure_timezone(request.end, request.timezone),
+        "attendees": [{"email": email} for email in request.attendees],
+    }
+    event_id = None
+    if request.idempotency_key:
+        event_id = request.idempotency_key.replace(" ", "-")
+        event_body["id"] = event_id
+    try:
+        created = service.events().insert(
+            calendarId=request.calendar_id,
+            body=event_body,
+            supportsAttachments=True,
+            sendUpdates="all",
+        ).execute()
+    except HttpError as error:
+        raise HTTPException(status_code=502, detail=str(error)) from error
+    return GCalCreateEventResponse(
+        event_id=created.get("id", event_id or ""),
+        html_link=created.get("htmlLink"),
+        status=created.get("status", "confirmed"),
+    )
+
+
+class GDriveUploadRequest(BaseModel):
+    user: str = Field(..., min_length=1)
+    agent: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+    mime_type: str = Field(..., min_length=1)
+    content_base64: str = Field(..., description="Base64-encoded file content")
+    folder_id: str | None = Field(default=None)
+
+
+class GDriveUploadResponse(BaseModel):
+    file_id: str
+    web_view_link: str | None
+
+
+@router.post("/google/gdrive/upload", name="gdrive.upload")
+def upload_to_gdrive(
+    request: GDriveUploadRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    auth_manager: GoogleAuthManager = Depends(get_google_auth_manager),
+) -> GDriveUploadResponse:
+    audit_logger.log("gdrive.upload", request.model_dump(exclude={"user"}), request.user)
+    try:
+        service = auth_manager.drive_service()
+    except GoogleCredentialsError as error:
+        raise HTTPException(status_code=500, detail=str(error)) from error
+    try:
+        binary_content = base64.b64decode(request.content_base64)
+    except binascii.Error as error:
+        raise HTTPException(status_code=400, detail="Invalid base64 content") from error
+    metadata: Dict[str, Any] = {"name": request.name}
+    if request.folder_id:
+        metadata["parents"] = [request.folder_id]
+    media = auth_manager.build_media(binary_content, request.mime_type)
+    try:
+        created = service.files().create(
+            body=metadata,
+            media_body=media,
+            fields="id, webViewLink",
+        ).execute()
+    except HttpError as error:
+        raise HTTPException(status_code=502, detail=str(error)) from error
+    return GDriveUploadResponse(
+        file_id=created.get("id", ""),
+        web_view_link=created.get("webViewLink"),
+    )

--- a/app/routes/memory.py
+++ b/app/routes/memory.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from app.dependencies import get_audit_logger, get_memory_store
+from app.services.audit import AuditLogger
+from app.services.memory_store import MemoryNote, MemoryStore
+
+router = APIRouter(tags=["memory"])
+
+
+class MemoryNotePayload(BaseModel):
+    text: str = Field(..., min_length=1)
+    tags: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    note_id: str | None = Field(default=None, description="Explicit note identifier to enforce idempotency")
+
+
+class MemoryNoteAddRequest(BaseModel):
+    user: str = Field(..., min_length=1)
+    agent: str = Field(..., min_length=1)
+    note: MemoryNotePayload
+
+
+class MemoryNoteModel(BaseModel):
+    note_id: str
+    text: str
+    tags: List[str]
+    metadata: Dict[str, Any]
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_domain(cls, note: MemoryNote) -> "MemoryNoteModel":
+        return cls(
+            note_id=note.note_id,
+            text=note.text,
+            tags=note.tags,
+            metadata=note.metadata,
+            created_at=note.created_at.isoformat(),
+            updated_at=note.updated_at.isoformat(),
+        )
+
+
+class MemoryNoteAddResponse(BaseModel):
+    note: MemoryNoteModel
+    created: bool
+
+
+class MemoryNoteFindRequest(BaseModel):
+    user: str = Field(..., min_length=1)
+    query: str = Field("", description="Full-text query string")
+    tags: List[str] = Field(default_factory=list)
+    limit: int = Field(20, ge=1, le=100)
+
+
+class MemoryNoteFindResponse(BaseModel):
+    results: List[MemoryNoteModel]
+
+
+@router.post("/memory/note/add", name="memory.note.add")
+def add_memory_note(
+    request: MemoryNoteAddRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    store: MemoryStore = Depends(get_memory_store),
+) -> MemoryNoteAddResponse:
+    audit_logger.log("memory.note.add", request.model_dump(exclude={"user"}), request.user)
+    note, created = store.add_note(
+        text=request.note.text,
+        tags=request.note.tags,
+        metadata=request.note.metadata,
+        note_id=request.note.note_id,
+    )
+    return MemoryNoteAddResponse(note=MemoryNoteModel.from_domain(note), created=created)
+
+
+@router.post("/memory/note/find", name="memory.note.find")
+def find_memory_notes(
+    request: MemoryNoteFindRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    store: MemoryStore = Depends(get_memory_store),
+) -> MemoryNoteFindResponse:
+    audit_logger.log("memory.note.find", request.model_dump(exclude={"user"}), request.user)
+    notes = store.find_notes(query=request.query, tags=request.tags, limit=request.limit)
+    return MemoryNoteFindResponse(results=[MemoryNoteModel.from_domain(note) for note in notes])

--- a/app/routes/n8n.py
+++ b/app/routes/n8n.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.dependencies import get_audit_logger, get_n8n_client
+from app.services.audit import AuditLogger
+from app.services.n8n_client import N8NClient, N8NConfigurationError
+
+router = APIRouter(tags=["n8n"])
+
+
+class N8NTriggerRequest(BaseModel):
+    user: str = Field(..., min_length=1)
+    agent: str = Field(..., min_length=1)
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str | None = Field(default=None)
+
+
+class N8NTriggerResponse(BaseModel):
+    result: Dict[str, Any]
+
+
+@router.post("/n8n/trigger", name="n8n.trigger")
+def trigger_workflow(
+    request: N8NTriggerRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    client: N8NClient = Depends(get_n8n_client),
+) -> N8NTriggerResponse:
+    audit_logger.log("n8n.trigger", request.model_dump(exclude={"user"}), request.user)
+    try:
+        result = client.trigger(request.payload, idempotency_key=request.idempotency_key or request.agent)
+    except N8NConfigurationError as error:
+        raise HTTPException(status_code=500, detail=str(error)) from error
+    except Exception as error:  # pragma: no cover - requests errors propagate
+        raise HTTPException(status_code=502, detail=str(error)) from error
+    return N8NTriggerResponse(result=result)

--- a/app/routes/rag.py
+++ b/app/routes/rag.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from uuid import uuid5, NAMESPACE_URL
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.dependencies import get_audit_logger, get_rag_service
+from app.services.audit import AuditLogger
+from app.services.rag_service import RAGDocument, RAGService
+
+router = APIRouter(tags=["rag"])
+
+
+class RAGDocumentPayload(BaseModel):
+    text: str = Field(..., min_length=1)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    document_id: str | None = Field(default=None, alias="id")
+
+    def compute_id(self) -> str:
+        base = self.document_id or str(uuid5(NAMESPACE_URL, self.text))
+        return base
+
+
+class RAGIndexRequest(BaseModel):
+    user: str = Field(..., min_length=1)
+    agent: str = Field(..., min_length=1)
+    collection: str = Field(..., min_length=1)
+    documents: List[RAGDocumentPayload]
+
+
+class RAGIndexResponse(BaseModel):
+    document_ids: List[str]
+
+
+class RAGQueryRequest(BaseModel):
+    user: str = Field(..., min_length=1)
+    collection: str = Field(..., min_length=1)
+    query: str = Field(..., min_length=1)
+    n_results: int = Field(5, ge=1, le=50)
+
+
+class RAGQueryResponse(BaseModel):
+    results: Dict[str, Any]
+
+
+@router.post("/rag/index", name="rag.index")
+def rag_index(
+    request: RAGIndexRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    service: RAGService = Depends(get_rag_service),
+) -> RAGIndexResponse:
+    audit_logger.log("rag.index", request.model_dump(exclude={"user"}), request.user)
+    if not request.documents:
+        raise HTTPException(status_code=400, detail="At least one document is required")
+    documents = [
+        RAGDocument(doc_id=doc.compute_id(), text=doc.text, metadata=doc.metadata)
+        for doc in request.documents
+    ]
+    try:
+        ids = service.index(request.collection, documents)
+    except Exception as error:  # pragma: no cover - chroma runtime errors
+        raise HTTPException(status_code=500, detail=str(error)) from error
+    return RAGIndexResponse(document_ids=ids)
+
+
+@router.post("/rag/query", name="rag.query")
+def rag_query(
+    request: RAGQueryRequest,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+    service: RAGService = Depends(get_rag_service),
+) -> RAGQueryResponse:
+    audit_logger.log("rag.query", request.model_dump(exclude={"user"}), request.user)
+    try:
+        result = service.query(request.collection, request.query, request.n_results)
+    except Exception as error:  # pragma: no cover
+        raise HTTPException(status_code=500, detail=str(error)) from error
+    return RAGQueryResponse(results=result)

--- a/app/routes/zep.py
+++ b/app/routes/zep.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from scripts.memory_zep_local import save_to_zep, search_zep
+
+router = APIRouter(prefix="/zep", tags=["zep"])
+
+
+class ZepPayload(BaseModel):
+    session_id: str
+    role: str
+    content: str
+
+
+@router.post("/save")
+def zep_save(payload: ZepPayload) -> dict:
+    try:
+        response = save_to_zep(payload.session_id, payload.role, payload.content)
+        return {"status": "ok", "zep_response": response.json()}
+    except Exception as error:  # pragma: no cover - upstream dependency
+        raise HTTPException(status_code=500, detail=str(error)) from error
+
+
+@router.get("/search")
+def zep_search(session_id: str = Query(...), query: str = Query(...)) -> dict:
+    try:
+        results = search_zep(session_id, query)
+        return {"status": "ok", "results": results}
+    except Exception as error:  # pragma: no cover - upstream dependency
+        raise HTTPException(status_code=500, detail=str(error)) from error

--- a/app/services/audit.py
+++ b/app/services/audit.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import threading
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Mapping
+
+
+class AuditLogger:
+    """Write NDJSON audit events with hashed arguments."""
+
+    def __init__(self, log_path: Path) -> None:
+        self._log_path = log_path
+        self._lock = threading.Lock()
+
+    def log(self, tool_name: str, args: Mapping[str, Any] | None, user: str) -> None:
+        payload = json.dumps(args or {}, default=self._default_serializer, sort_keys=True)
+        args_hash = sha256(payload.encode("utf-8")).hexdigest()
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "tool": tool_name,
+            "args_hash": args_hash,
+            "user": user,
+        }
+        line = json.dumps(entry, sort_keys=True, ensure_ascii=False)
+        self._log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock:
+            with self._log_path.open("a", encoding="utf-8") as handle:
+                handle.write(f"{line}\n")
+
+    @staticmethod
+    def _default_serializer(value: Any) -> Any:
+        if isinstance(value, Path):
+            return str(value)
+        if isinstance(value, datetime):
+            return value.isoformat()
+        raise TypeError(f"Object of type {type(value)!r} is not JSON serializable")

--- a/app/services/bus_service.py
+++ b/app/services/bus_service.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence
+from uuid import uuid4
+
+from googleapiclient.errors import HttpError
+
+from app.services.google_clients import GoogleAuthManager, serialize_metadata
+
+
+class BusServiceError(RuntimeError):
+    pass
+
+
+class BusService:
+    def __init__(self, auth_manager: GoogleAuthManager) -> None:
+        self._auth_manager = auth_manager
+
+    def send(self, spreadsheet_id: str, worksheet: str, payload: Dict[str, Any], user: str, agent: str, idempotency_key: str | None = None) -> Dict[str, Any]:
+        message_id = idempotency_key or str(uuid4())
+        timestamp = datetime.now(timezone.utc).isoformat()
+        row = [
+            message_id,
+            timestamp,
+            user,
+            agent,
+            "pending",
+            serialize_metadata(payload),
+        ]
+        service = self._auth_manager.sheets_service()
+        try:
+            service.spreadsheets().values().append(
+                spreadsheetId=spreadsheet_id,
+                range=f"{worksheet}!A:F",
+                valueInputOption="RAW",
+                body={"values": [row]},
+            ).execute()
+        except HttpError as error:
+            raise BusServiceError(str(error)) from error
+        return {"message_id": message_id, "status": "pending", "timestamp": timestamp}
+
+    def poll(self, spreadsheet_id: str, worksheet: str, status: Optional[str], limit: int) -> List[Dict[str, Any]]:
+        service = self._auth_manager.sheets_service()
+        try:
+            result = service.spreadsheets().values().get(
+                spreadsheetId=spreadsheet_id,
+                range=f"{worksheet}!A:F",
+            ).execute()
+        except HttpError as error:
+            raise BusServiceError(str(error)) from error
+        values = result.get("values", [])
+        records: List[Dict[str, Any]] = []
+        for row in values[1:]:
+            record = self._row_to_record(row)
+            if status and record["status"].lower() != status.lower():
+                continue
+            records.append(record)
+            if len(records) >= limit:
+                break
+        return records
+
+    def update_status(self, spreadsheet_id: str, worksheet: str, message_id: str, status: str) -> Dict[str, Any]:
+        service = self._auth_manager.sheets_service()
+        try:
+            result = service.spreadsheets().values().get(
+                spreadsheetId=spreadsheet_id,
+                range=f"{worksheet}!A:F",
+            ).execute()
+        except HttpError as error:
+            raise BusServiceError(str(error)) from error
+        values = result.get("values", [])
+        for index, row in enumerate(values, start=1):
+            if row and row[0] == message_id:
+                update_range = f"{worksheet}!E{index}"
+                try:
+                    service.spreadsheets().values().update(
+                        spreadsheetId=spreadsheet_id,
+                        range=update_range,
+                        valueInputOption="RAW",
+                        body={"values": [[status]]},
+                    ).execute()
+                except HttpError as error:
+                    raise BusServiceError(str(error)) from error
+                return {"message_id": message_id, "status": status}
+        raise BusServiceError(f"Message {message_id} not found")
+
+    @staticmethod
+    def _row_to_record(row: Sequence[str]) -> Dict[str, Any]:
+        padded = list(row) + [""] * max(0, 6 - len(row))
+        return {
+            "message_id": padded[0],
+            "timestamp": padded[1],
+            "user": padded[2],
+            "agent": padded[3],
+            "status": padded[4],
+            "payload": json.loads(padded[5]) if padded[5] else {},
+        }

--- a/app/services/git_ops.py
+++ b/app/services/git_ops.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+class GitOpsError(RuntimeError):
+    """Raised when git operations fail."""
+
+
+class GitOpsHelper:
+    def __init__(self, repo_root: Path) -> None:
+        self._repo_root = repo_root
+
+    def commit_and_push(self, tool: str, file_path: Path, agent: str, content_hash: str) -> Optional[str]:
+        relative_path = file_path.relative_to(self._repo_root)
+        timestamp = datetime.now(timezone.utc).isoformat()
+        message = f"[{tool}] {relative_path} {content_hash} by {agent} {timestamp}"
+        self._run(["git", "add", str(relative_path)])
+        try:
+            self._run(["git", "commit", "-m", message])
+        except GitOpsError as error:
+            if "nothing to commit" in str(error).lower():
+                return None
+            raise
+        remote_output = self._run(["git", "remote"], capture_output=True)
+        remote_names = [line.strip() for line in remote_output.splitlines() if line.strip()]
+        if not remote_names:
+            return message
+        self._run(["git", "push"])
+        return message
+
+    def _run(self, command: list[str], capture_output: bool = False) -> str:
+        result = subprocess.run(
+            command,
+            cwd=self._repo_root,
+            check=False,
+            capture_output=capture_output,
+            text=True,
+        )
+        if result.returncode != 0:
+            output = result.stderr.strip() or result.stdout.strip()
+            raise GitOpsError(output or f"Command {' '.join(command)} failed")
+        if capture_output:
+            return result.stdout
+        return ""

--- a/app/services/google_clients.py
+++ b/app/services/google_clients.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaInMemoryUpload
+
+
+class GoogleCredentialsError(RuntimeError):
+    pass
+
+
+class GoogleAuthManager:
+    def __init__(self, credentials_path: Path | None = None) -> None:
+        self._credentials_path = self._resolve_credentials_path(credentials_path)
+
+    def _resolve_credentials_path(self, candidate: Path | None) -> Path:
+        if candidate and candidate.exists():
+            return candidate
+        env_path = os.getenv("GOOGLE_CREDENTIALS_FILE")
+        if env_path:
+            path = Path(env_path)
+            if path.exists():
+                return path
+        default_candidates = [
+            Path("/vault/secrets/google_service_account.json"),
+            Path("/workspace/secrets/google_service_account.json"),
+        ]
+        for item in default_candidates:
+            if item.exists():
+                return item
+        raise GoogleCredentialsError("Google service account credentials not found")
+
+    def calendar_service(self):
+        credentials = service_account.Credentials.from_service_account_file(
+            str(self._credentials_path),
+            scopes=[
+                "https://www.googleapis.com/auth/calendar",
+            ],
+        )
+        return build("calendar", "v3", credentials=credentials, cache_discovery=False)
+
+    def drive_service(self):
+        credentials = service_account.Credentials.from_service_account_file(
+            str(self._credentials_path),
+            scopes=[
+                "https://www.googleapis.com/auth/drive.file",
+            ],
+        )
+        return build("drive", "v3", credentials=credentials, cache_discovery=False)
+
+    def sheets_service(self):
+        credentials = service_account.Credentials.from_service_account_file(
+            str(self._credentials_path),
+            scopes=[
+                "https://www.googleapis.com/auth/spreadsheets",
+            ],
+        )
+        return build("sheets", "v4", credentials=credentials, cache_discovery=False)
+
+    @staticmethod
+    def build_media(body: bytes, mime_type: str):
+        return MediaInMemoryUpload(body, mimetype=mime_type, resumable=False)
+
+
+def serialize_metadata(metadata: Dict[str, Any]) -> str:
+    return json.dumps(metadata, sort_keys=True, ensure_ascii=False)

--- a/app/services/memory_store.py
+++ b/app/services/memory_store.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+from uuid import uuid5, NAMESPACE_URL
+import gzip
+
+
+@dataclass(slots=True)
+class MemoryNote:
+    note_id: str
+    text: str
+    tags: List[str]
+    metadata: Dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["created_at"] = self.created_at.isoformat()
+        data["updated_at"] = self.updated_at.isoformat()
+        return data
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "MemoryNote":
+        return cls(
+            note_id=payload["note_id"],
+            text=payload["text"],
+            tags=list(payload.get("tags", [])),
+            metadata=dict(payload.get("metadata", {})),
+            created_at=datetime.fromisoformat(payload["created_at"]),
+            updated_at=datetime.fromisoformat(payload["updated_at"]),
+        )
+
+
+class MemoryStore:
+    def __init__(self, base_path: Path) -> None:
+        self._base_path = base_path
+        self._json_path = self._base_path / "sentra_memory.json"
+        self._archives_dir = self._base_path / "archives"
+        self._base_path.mkdir(parents=True, exist_ok=True)
+        self._archives_dir.mkdir(parents=True, exist_ok=True)
+
+    def add_note(self, text: str, tags: Sequence[str], metadata: Dict[str, Any], note_id: str | None = None) -> Tuple[MemoryNote, bool]:
+        notes = self._load_notes()
+        normalized_tags = sorted(set(tags))
+        payload = json.dumps({"text": text, "tags": normalized_tags, "metadata": metadata}, sort_keys=True)
+        computed_id = note_id or str(uuid5(NAMESPACE_URL, payload))
+        now = datetime.now(timezone.utc)
+        existing = next((note for note in notes if note.note_id == computed_id), None)
+        if existing:
+            return existing, False
+        new_note = MemoryNote(
+            note_id=computed_id,
+            text=text,
+            tags=list(normalized_tags),
+            metadata=dict(metadata),
+            created_at=now,
+            updated_at=now,
+        )
+        notes.append(new_note)
+        self._write_notes(notes)
+        self._write_archive(new_note)
+        return new_note, True
+
+    def find_notes(self, query: str, tags: Sequence[str] | None = None, limit: int = 20) -> List[MemoryNote]:
+        notes = self._load_notes()
+        filtered: Iterable[MemoryNote] = notes
+        lowered_query = query.lower()
+        if lowered_query:
+            filtered = (note for note in filtered if lowered_query in note.text.lower() or lowered_query in json.dumps(note.metadata).lower())
+        if tags:
+            tags_set = {tag.lower() for tag in tags}
+            filtered = (
+                note for note in filtered if tags_set.issubset({tag.lower() for tag in note.tags})
+            )
+        results = []
+        for note in filtered:
+            results.append(note)
+            if len(results) >= limit:
+                break
+        return results
+
+    def _load_notes(self) -> List[MemoryNote]:
+        if not self._json_path.exists():
+            return []
+        data = json.loads(self._json_path.read_text(encoding="utf-8"))
+        return [MemoryNote.from_dict(item) for item in data]
+
+    def _write_notes(self, notes: Sequence[MemoryNote]) -> None:
+        serialized = [note.to_dict() for note in notes]
+        self._json_path.write_text(json.dumps(serialized, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def _write_archive(self, note: MemoryNote) -> None:
+        archive_path = self._archives_dir / f"{note.note_id}.zmem"
+        if archive_path.exists():
+            return
+        payload = json.dumps(note.to_dict(), ensure_ascii=False).encode("utf-8")
+        with gzip.open(archive_path, "wb") as handle:
+            handle.write(payload)

--- a/app/services/n8n_client.py
+++ b/app/services/n8n_client.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+import os
+
+import requests
+
+
+class N8NConfigurationError(RuntimeError):
+    pass
+
+
+class N8NClient:
+    def __init__(self, webhook_url: str | None = None, timeout: int = 10) -> None:
+        self._webhook_url = webhook_url or os.getenv("N8N_WEBHOOK_URL")
+        self._timeout = timeout
+        if not self._webhook_url:
+            raise N8NConfigurationError("N8N webhook URL is not configured")
+
+    def trigger(self, payload: Dict[str, Any], idempotency_key: str | None = None) -> Dict[str, Any]:
+        headers: Dict[str, str] = {}
+        if idempotency_key:
+            headers["Idempotency-Key"] = idempotency_key
+        response = requests.post(self._webhook_url, json=payload, headers=headers, timeout=self._timeout)
+        response.raise_for_status()
+        try:
+            return response.json()
+        except ValueError:
+            return {"status_code": response.status_code, "content": response.text}

--- a/app/services/paths.py
+++ b/app/services/paths.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+ALLOWED_ROOTS: Dict[str, Path] = {
+    "projects": BASE_DIR / "projects",
+    "reports": BASE_DIR / "reports",
+    "students": BASE_DIR / "students",
+}
+
+
+def ensure_allowed_root(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def resolve_workspace_path(path_value: str) -> Path:
+    normalized = path_value.strip()
+    if normalized.startswith("/"):
+        normalized = normalized[1:]
+    parts = normalized.split("/", 1)
+    root_key = parts[0]
+    if root_key not in ALLOWED_ROOTS:
+        raise ValueError("Path must begin with /projects, /reports, or /students")
+    base = ALLOWED_ROOTS[root_key]
+    ensure_allowed_root(base)
+    relative = parts[1] if len(parts) > 1 else ""
+    target = (base / relative).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        raise ValueError("Path traversal detected") from exc
+    return target

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Sequence
+from pathlib import Path
+from threading import Lock
+
+import chromadb
+
+
+@dataclass(slots=True)
+class RAGDocument:
+    doc_id: str
+    text: str
+    metadata: Dict[str, Any]
+
+
+class RAGService:
+    def __init__(self, persist_directory: Path) -> None:
+        self._persist_directory = persist_directory
+        self._persist_directory.mkdir(parents=True, exist_ok=True)
+        self._client = chromadb.PersistentClient(path=str(self._persist_directory))
+        self._lock = Lock()
+
+    def index(self, collection_name: str, documents: Sequence[RAGDocument]) -> List[str]:
+        with self._lock:
+            collection = self._client.get_or_create_collection(name=collection_name)
+            ids = [doc.doc_id for doc in documents]
+            texts = [doc.text for doc in documents]
+            metadatas = [self._normalize_metadata(doc.metadata) for doc in documents]
+            collection.upsert(ids=ids, documents=texts, metadatas=metadatas)
+            return ids
+
+    def query(self, collection_name: str, query_text: str, n_results: int) -> Dict[str, Any]:
+        collection = self._client.get_or_create_collection(name=collection_name)
+        result = collection.query(query_texts=[query_text], n_results=n_results)
+        return result
+
+    @staticmethod
+    def _normalize_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
+        normalized: Dict[str, Any] = {}
+        for key, value in metadata.items():
+            normalized[key] = value if isinstance(value, (str, int, float, bool)) else str(value)
+        return normalized

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,9 @@ requests==2.32.1
 unicodedata2 ; sys_platform == 'win32'
 packaging
 
-fastapi
+fastapi>=0.110.0
 uvicorn
+pydantic>=2.0.0,<3.0.0
+chromadb>=0.5.0
+google-auth>=2.0.0
+google-api-python-client>=2.0.0


### PR DESCRIPTION
## Summary
- refactor the FastAPI entrypoint into a modular application factory and register dedicated routers for files, memory, n8n, Google, bus, and rag MCP tools
- implement service layers for audit logging, git operations, Google clients, memory storage, n8n triggers, and Chroma-backed RAG to keep handlers thin and idempotent
- add NDJSON audit logging, shared git helper commits, and request validation that constrain file paths and persist memory notes with zipped archives
- wire Google Calendar/Drive, Sheets-backed bus, and Chroma search capabilities while capturing configuration via reusable dependencies

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd9e239ff48331a7da46929aaf2e32