### PR TITLE
Handle git push retries with idempotency cache

### DIFF
--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -84,7 +84,13 @@ def write_file(
     target_path.write_text(request.content, encoding="utf-8")
     digest = sha256(request.content.encode("utf-8")).hexdigest()
     try:
-        commit_message = git_helper.commit_and_push("files.write", target_path, request.agent, digest)
+        commit_message = git_helper.commit_and_push(
+            "files.write",
+            target_path,
+            request.agent,
+            digest,
+            idempotency_key=request.idempotency_key,
+        )
     except GitOpsError as error:
         raise HTTPException(status_code=500, detail=str(error)) from error
     return FileWriteResponse(

--- a/app/services/git_ops.py
+++ b/app/services/git_ops.py
@@ -9,12 +9,26 @@ from typing import Optional
 class GitOpsError(RuntimeError):
     """Raised when git operations fail."""
 
+    def __init__(self, message: str, returncode: int | None = None) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+
 
 class GitOpsHelper:
     def __init__(self, repo_root: Path) -> None:
         self._repo_root = repo_root
+        self._idempotency_cache: dict[str, Optional[str]] = {}
 
-    def commit_and_push(self, tool: str, file_path: Path, agent: str, content_hash: str) -> Optional[str]:
+    def commit_and_push(
+        self,
+        tool: str,
+        file_path: Path,
+        agent: str,
+        content_hash: str,
+        idempotency_key: str | None = None,
+    ) -> Optional[str]:
+        if idempotency_key and idempotency_key in self._idempotency_cache:
+            return self._idempotency_cache[idempotency_key]
         relative_path = file_path.relative_to(self._repo_root)
         timestamp = datetime.now(timezone.utc).isoformat()
         message = f"[{tool}] {relative_path} {content_hash} by {agent} {timestamp}"
@@ -23,14 +37,28 @@ class GitOpsHelper:
             self._run(["git", "commit", "-m", message])
         except GitOpsError as error:
             if "nothing to commit" in str(error).lower():
+                if idempotency_key:
+                    self._idempotency_cache[idempotency_key] = None
                 return None
             raise
         remote_output = self._run(["git", "remote"], capture_output=True)
         remote_names = [line.strip() for line in remote_output.splitlines() if line.strip()]
-        if not remote_names:
-            return message
-        self._run(["git", "push"])
-        return message
+        commit_message: Optional[str] = message
+        if remote_names:
+            try:
+                self._run(["git", "push"])
+            except GitOpsError as error:
+                if error.returncode == 128:
+                    try:
+                        self._run(["git", "pull", "--rebase"])
+                    except GitOpsError:
+                        self._run(["git", "fetch", "--all"])
+                    self._run(["git", "push"])
+                else:
+                    raise
+        if idempotency_key:
+            self._idempotency_cache[idempotency_key] = commit_message
+        return commit_message
 
     def _run(self, command: list[str], capture_output: bool = False) -> str:
         result = subprocess.run(
@@ -42,7 +70,7 @@ class GitOpsHelper:
         )
         if result.returncode != 0:
             output = result.stderr.strip() or result.stdout.strip()
-            raise GitOpsError(output or f"Command {' '.join(command)} failed")
+            raise GitOpsError(output or f"Command {' '.join(command)} failed", returncode=result.returncode)
         if capture_output:
             return result.stdout
         return ""

--- a/tests/test_git_ops_helper.py
+++ b/tests/test_git_ops_helper.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from app.services.git_ops import GitOpsError, GitOpsHelper
+
+
+def test_commit_and_push_retries_after_pull(tmp_path, monkeypatch):
+    repo_root = tmp_path
+    helper = GitOpsHelper(repo_root)
+    file_path = repo_root / "example.txt"
+    file_path.write_text("content", encoding="utf-8")
+
+    commands: list[list[str]] = []
+    push_attempts = {"count": 0}
+
+    def fake_run(command: list[str], capture_output: bool = False) -> str:
+        commands.append(command)
+        if command[:2] == ["git", "add"]:
+            return ""
+        if command[:2] == ["git", "commit"]:
+            return ""
+        if command[:2] == ["git", "remote"]:
+            return "origin\n" if capture_output else ""
+        if command[:3] == ["git", "pull", "--rebase"]:
+            return ""
+        if command[:2] == ["git", "fetch"]:
+            return ""
+        if command[:2] == ["git", "push"]:
+            push_attempts["count"] += 1
+            if push_attempts["count"] == 1:
+                raise GitOpsError("fatal: remote rejected", returncode=128)
+            return ""
+        raise AssertionError(f"Unexpected git command: {command}")
+
+    monkeypatch.setattr(helper, "_run", fake_run)
+
+    message = helper.commit_and_push("tool", file_path, "agent", "hash")
+
+    assert push_attempts["count"] == 2
+    assert ["git", "pull", "--rebase"] in commands or ["git", "fetch", "--all"] in commands
+    assert message is not None
+    assert "[tool]" in message
+
+
+def test_commit_and_push_short_circuits_with_idempotency(tmp_path, monkeypatch):
+    repo_root = tmp_path
+    helper = GitOpsHelper(repo_root)
+    file_path = repo_root / "another.txt"
+    file_path.write_text("content", encoding="utf-8")
+
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], capture_output: bool = False) -> str:
+        commands.append(command)
+        if command[:2] == ["git", "add"]:
+            return ""
+        if command[:2] == ["git", "commit"]:
+            return ""
+        if command[:2] == ["git", "remote"]:
+            return ""
+        raise AssertionError(f"Unexpected git command: {command}")
+
+    monkeypatch.setattr(helper, "_run", fake_run)
+
+    first_message = helper.commit_and_push("tool", file_path, "agent", "hash", idempotency_key="abc")
+    command_count = len(commands)
+
+    second_message = helper.commit_and_push("tool", file_path, "agent", "hash", idempotency_key="abc")
+
+    assert len(commands) == command_count
+    assert second_message == first_message


### PR DESCRIPTION
## Summary
- propagate the optional file write idempotency key into the Git helper so repeat requests can short-circuit
- add idempotency caching plus a retry-once path that pulls/rebases before pushing after exit 128 failures
- exercise the retry and caching behaviour with new GitOpsHelper unit tests

## Testing
- pytest tests/test_git_ops_helper.py

------
https://chatgpt.com/codex/tasks/task_e_68cda7d8c37883319c4915857adb8871