### PR TITLE
Expand bus sheet schema and trigger dispatch workflow

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -41,7 +41,10 @@ def get_google_auth_manager() -> GoogleAuthManager:
 
 @lru_cache(maxsize=1)
 def get_bus_service() -> BusService:
-    return BusService(auth_manager=get_google_auth_manager())
+    return BusService(
+        auth_manager=get_google_auth_manager(),
+        n8n_client=get_n8n_client(),
+    )
 
 
 @lru_cache(maxsize=1)

--- a/app/services/bus_service.py
+++ b/app/services/bus_service.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from googleapiclient.errors import HttpError
 
 from app.services.google_clients import GoogleAuthManager, serialize_metadata
+from app.services.n8n_client import N8NClient, N8NConfigurationError
 
 
 class BusServiceError(RuntimeError):
@@ -15,38 +16,85 @@ class BusServiceError(RuntimeError):
 
 
 class BusService:
-    def __init__(self, auth_manager: GoogleAuthManager) -> None:
+    def __init__(self, auth_manager: GoogleAuthManager, n8n_client: N8NClient) -> None:
         self._auth_manager = auth_manager
+        self._n8n_client = n8n_client
 
-    def send(self, spreadsheet_id: str, worksheet: str, payload: Dict[str, Any], user: str, agent: str, idempotency_key: str | None = None) -> Dict[str, Any]:
+    def send(
+        self,
+        spreadsheet_id: str,
+        worksheet: str,
+        sender: str,
+        recipient: str,
+        topic: str,
+        goal: str,
+        context_json: Dict[str, Any],
+        user: str,
+        idempotency_key: str | None = None,
+    ) -> Dict[str, Any]:
         message_id = idempotency_key or str(uuid4())
         timestamp = datetime.now(timezone.utc).isoformat()
         row = [
             message_id,
             timestamp,
-            user,
-            agent,
+            sender,
+            recipient,
+            topic,
+            goal,
+            serialize_metadata(context_json),
             "pending",
-            serialize_metadata(payload),
+            "",
+            timestamp,
         ]
         service = self._auth_manager.sheets_service()
         try:
             service.spreadsheets().values().append(
                 spreadsheetId=spreadsheet_id,
-                range=f"{worksheet}!A:F",
+                range=f"{worksheet}!A:J",
                 valueInputOption="RAW",
                 body={"values": [row]},
             ).execute()
         except HttpError as error:
             raise BusServiceError(str(error)) from error
-        return {"message_id": message_id, "status": "pending", "timestamp": timestamp}
+
+        dispatch_payload = {
+            "workflow": "bus-dispatch",
+            "spreadsheet_id": spreadsheet_id,
+            "worksheet": worksheet,
+            "id": message_id,
+            "from": sender,
+            "to": recipient,
+            "topic": topic,
+            "goal": goal,
+            "context_json": context_json,
+            "ts": timestamp,
+        }
+        try:
+            self._n8n_client.trigger(dispatch_payload, idempotency_key=message_id)
+        except N8NConfigurationError as error:
+            raise BusServiceError(str(error)) from error
+        except Exception as error:  # pragma: no cover - network errors propagate
+            raise BusServiceError(str(error)) from error
+
+        return {
+            "id": message_id,
+            "ts": timestamp,
+            "from": sender,
+            "to": recipient,
+            "topic": topic,
+            "goal": goal,
+            "context_json": context_json,
+            "status": "pending",
+            "error": "",
+            "last_update": timestamp,
+        }
 
     def poll(self, spreadsheet_id: str, worksheet: str, status: Optional[str], limit: int) -> List[Dict[str, Any]]:
         service = self._auth_manager.sheets_service()
         try:
             result = service.spreadsheets().values().get(
                 spreadsheetId=spreadsheet_id,
-                range=f"{worksheet}!A:F",
+                range=f"{worksheet}!A:J",
             ).execute()
         except HttpError as error:
             raise BusServiceError(str(error)) from error
@@ -61,39 +109,60 @@ class BusService:
                 break
         return records
 
-    def update_status(self, spreadsheet_id: str, worksheet: str, message_id: str, status: str) -> Dict[str, Any]:
+    def update_status(
+        self,
+        spreadsheet_id: str,
+        worksheet: str,
+        message_id: str,
+        status: str,
+        error: Optional[str] = None,
+    ) -> Dict[str, Any]:
         service = self._auth_manager.sheets_service()
         try:
             result = service.spreadsheets().values().get(
                 spreadsheetId=spreadsheet_id,
-                range=f"{worksheet}!A:F",
+                range=f"{worksheet}!A:J",
             ).execute()
         except HttpError as error:
             raise BusServiceError(str(error)) from error
         values = result.get("values", [])
         for index, row in enumerate(values, start=1):
             if row and row[0] == message_id:
-                update_range = f"{worksheet}!E{index}"
+                padded = list(row) + [""] * max(0, 10 - len(row))
+                error_value = error if error is not None else padded[8]
+                timestamp = datetime.now(timezone.utc).isoformat()
+                update_range = f"{worksheet}!H{index}:J{index}"
                 try:
                     service.spreadsheets().values().update(
                         spreadsheetId=spreadsheet_id,
                         range=update_range,
                         valueInputOption="RAW",
-                        body={"values": [[status]]},
+                        body={"values": [[status, error_value, timestamp]]},
                     ).execute()
                 except HttpError as error:
                     raise BusServiceError(str(error)) from error
-                return {"message_id": message_id, "status": status}
+                padded[7] = status
+                padded[8] = error_value
+                padded[9] = timestamp
+                return self._row_to_record(padded)
         raise BusServiceError(f"Message {message_id} not found")
 
     @staticmethod
     def _row_to_record(row: Sequence[str]) -> Dict[str, Any]:
-        padded = list(row) + [""] * max(0, 6 - len(row))
+        padded = list(row) + [""] * max(0, 10 - len(row))
+        try:
+            context = json.loads(padded[6]) if padded[6] else {}
+        except json.JSONDecodeError:
+            context = {}
         return {
-            "message_id": padded[0],
-            "timestamp": padded[1],
-            "user": padded[2],
-            "agent": padded[3],
-            "status": padded[4],
-            "payload": json.loads(padded[5]) if padded[5] else {},
+            "id": padded[0],
+            "ts": padded[1],
+            "from": padded[2],
+            "to": padded[3],
+            "topic": padded[4],
+            "goal": padded[5],
+            "context_json": context,
+            "status": padded[7],
+            "error": padded[8],
+            "last_update": padded[9],
         }

--- a/scripts/api_sentra.py
+++ b/scripts/api_sentra.py
@@ -622,7 +622,7 @@ async def get_memorial(project: str = "sentra_core"):
     memorial_file = safe_join(BASE_DIR, "projects", project_slug, "fichiers", "Z_MEMORIAL.md")
 
     if not memorial_file.exists():
-        raise HTTPException(status_code=404, detail="Z_MEMORIAL.md non trouvé")
+        return PlainTextResponse("Z_MEMORIAL.md non trouvé")
 
     try:
         content = memorial_file.read_text(encoding="utf-8")

--- a/tests/test_bus_service.py
+++ b/tests/test_bus_service.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from uuid import UUID
+
+import pytest
+
+# Provide a lightweight stub for the Google API client to avoid importing the real package during tests.
+import sys
+import types
+
+if "googleapiclient" not in sys.modules:
+    googleapiclient_module = types.ModuleType("googleapiclient")
+    errors_module = types.ModuleType("googleapiclient.errors")
+    discovery_module = types.ModuleType("googleapiclient.discovery")
+    http_module = types.ModuleType("googleapiclient.http")
+
+    class _HttpError(Exception):
+        pass
+
+    def _build(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("googleapiclient discovery build should not be called in tests")
+
+    class _MediaInMemoryUpload:  # pragma: no cover - simple stub
+        def __init__(self, body: bytes, mimetype: str, resumable: bool = False) -> None:
+            self.body = body
+            self.mimetype = mimetype
+            self.resumable = resumable
+
+    errors_module.HttpError = _HttpError
+    discovery_module.build = _build
+    http_module.MediaInMemoryUpload = _MediaInMemoryUpload
+
+    googleapiclient_module.errors = errors_module
+    googleapiclient_module.discovery = discovery_module
+    googleapiclient_module.http = http_module
+
+    sys.modules["googleapiclient"] = googleapiclient_module
+    sys.modules["googleapiclient.errors"] = errors_module
+    sys.modules["googleapiclient.discovery"] = discovery_module
+    sys.modules["googleapiclient.http"] = http_module
+
+if "google" not in sys.modules:
+    google_module = types.ModuleType("google")
+    sys.modules["google"] = google_module
+
+if "google.oauth2" not in sys.modules:
+    oauth2_module = types.ModuleType("google.oauth2")
+    sys.modules["google.oauth2"] = oauth2_module
+else:
+    oauth2_module = sys.modules["google.oauth2"]
+
+service_account_module = types.ModuleType("google.oauth2.service_account")
+
+
+class _Credentials:  # pragma: no cover - simple stub
+    @staticmethod
+    def from_service_account_file(*args: object, **kwargs: object) -> object:
+        return object()
+
+
+service_account_module.Credentials = _Credentials
+oauth2_module.service_account = service_account_module
+sys.modules["google.oauth2.service_account"] = service_account_module
+sys.modules["google"].oauth2 = oauth2_module
+
+from app.services import bus_service
+from app.services.bus_service import BusService, BusServiceError
+
+
+class _FakeExecutor:
+    def __init__(self, result: Dict[str, Any] | None = None) -> None:
+        self._result = result or {}
+
+    def execute(self) -> Dict[str, Any]:
+        return self._result
+
+
+class _FakeValuesResource:
+    def __init__(self, values: List[List[str]] | None = None) -> None:
+        self.values_data = values or []
+        self.append_calls: List[Dict[str, Any]] = []
+        self.update_calls: List[Dict[str, Any]] = []
+
+    def append(
+        self,
+        spreadsheetId: str,
+        range: str,
+        valueInputOption: str,
+        body: Dict[str, Any],
+    ) -> _FakeExecutor:
+        self.append_calls.append(
+            {
+                "spreadsheetId": spreadsheetId,
+                "range": range,
+                "valueInputOption": valueInputOption,
+                "body": body,
+            }
+        )
+        return _FakeExecutor()
+
+    def get(self, spreadsheetId: str, range: str) -> _FakeExecutor:  # type: ignore[override]
+        return _FakeExecutor({"values": self.values_data})
+
+    def update(
+        self,
+        spreadsheetId: str,
+        range: str,
+        valueInputOption: str,
+        body: Dict[str, Any],
+    ) -> _FakeExecutor:
+        self.update_calls.append(
+            {
+                "spreadsheetId": spreadsheetId,
+                "range": range,
+                "valueInputOption": valueInputOption,
+                "body": body,
+            }
+        )
+        return _FakeExecutor()
+
+
+class _FakeSpreadsheetsResource:
+    def __init__(self, values_resource: _FakeValuesResource) -> None:
+        self._values_resource = values_resource
+
+    def values(self) -> _FakeValuesResource:
+        return self._values_resource
+
+
+class _FakeSheetsService:
+    def __init__(self, values_resource: _FakeValuesResource) -> None:
+        self._spreadsheets = _FakeSpreadsheetsResource(values_resource)
+
+    def spreadsheets(self) -> _FakeSpreadsheetsResource:
+        return self._spreadsheets
+
+
+class _FakeAuthManager:
+    def __init__(self, service: _FakeSheetsService) -> None:
+        self._service = service
+
+    def sheets_service(self) -> _FakeSheetsService:
+        return self._service
+
+
+class _FakeN8NClient:
+    def __init__(self) -> None:
+        self.trigger_calls: List[Dict[str, Any]] = []
+
+    def trigger(self, payload: Dict[str, Any], idempotency_key: str | None = None) -> Dict[str, Any]:
+        self.trigger_calls.append({"payload": payload, "idempotency_key": idempotency_key})
+        return {"status": "accepted"}
+
+
+def _build_service(values: List[List[str]] | None = None) -> tuple[BusService, _FakeValuesResource, _FakeN8NClient]:
+    values_resource = _FakeValuesResource(values)
+    service = _FakeSheetsService(values_resource)
+    auth_manager = _FakeAuthManager(service)
+    n8n_client = _FakeN8NClient()
+    bus = BusService(auth_manager=auth_manager, n8n_client=n8n_client)
+    return bus, values_resource, n8n_client
+
+
+def test_send_appends_full_row_and_triggers_workflow(monkeypatch: pytest.MonkeyPatch) -> None:
+    fixed_timestamp = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+    class _FixedDatetime:
+        @classmethod
+        def now(cls, tz: timezone | None = None) -> datetime:
+            assert tz == timezone.utc
+            return fixed_timestamp
+
+    monkeypatch.setattr(bus_service, "datetime", _FixedDatetime)
+    monkeypatch.setattr(bus_service, "uuid4", lambda: UUID("12345678-1234-5678-1234-567812345678"))
+
+    bus, values_resource, n8n_client = _build_service()
+
+    result = bus.send(
+        spreadsheet_id="sheet-123",
+        worksheet="Bus",
+        sender="orchestrator",
+        recipient="codexpert",
+        topic="Spec review",
+        goal="Summarize the draft",
+        context_json={"foo": "bar", "nested": {"x": 1}},
+        user="orchestrator",
+    )
+
+    assert len(values_resource.append_calls) == 1
+    append_call = values_resource.append_calls[0]
+    assert append_call["range"] == "Bus!A:J"
+    assert append_call["valueInputOption"] == "RAW"
+    appended_row = append_call["body"]["values"][0]
+    assert appended_row[0] == "12345678-1234-5678-1234-567812345678"
+    assert appended_row[1] == fixed_timestamp.isoformat()
+    assert appended_row[2:6] == ["orchestrator", "codexpert", "Spec review", "Summarize the draft"]
+    assert appended_row[6] == json.dumps({"foo": "bar", "nested": {"x": 1}}, sort_keys=True, ensure_ascii=False)
+    assert appended_row[7:] == ["pending", "", fixed_timestamp.isoformat()]
+
+    assert len(n8n_client.trigger_calls) == 1
+    trigger_call = n8n_client.trigger_calls[0]
+    assert trigger_call["idempotency_key"] == "12345678-1234-5678-1234-567812345678"
+    assert trigger_call["payload"] == {
+        "workflow": "bus-dispatch",
+        "spreadsheet_id": "sheet-123",
+        "worksheet": "Bus",
+        "id": "12345678-1234-5678-1234-567812345678",
+        "from": "orchestrator",
+        "to": "codexpert",
+        "topic": "Spec review",
+        "goal": "Summarize the draft",
+        "context_json": {"foo": "bar", "nested": {"x": 1}},
+        "ts": fixed_timestamp.isoformat(),
+    }
+
+    assert result == {
+        "id": "12345678-1234-5678-1234-567812345678",
+        "ts": fixed_timestamp.isoformat(),
+        "from": "orchestrator",
+        "to": "codexpert",
+        "topic": "Spec review",
+        "goal": "Summarize the draft",
+        "context_json": {"foo": "bar", "nested": {"x": 1}},
+        "status": "pending",
+        "error": "",
+        "last_update": fixed_timestamp.isoformat(),
+    }
+
+
+def test_poll_filters_records_by_status() -> None:
+    values = [
+        ["id", "ts", "from", "to", "topic", "goal", "context_json", "status", "error", "last_update"],
+        [
+            "msg-1",
+            "2024-01-01T00:00:00+00:00",
+            "orchestrator",
+            "codexpert",
+            "Spec",
+            "Goal",
+            json.dumps({"alpha": 1}),
+            "pending",
+            "",
+            "2024-01-01T00:00:00+00:00",
+        ],
+        [
+            "msg-2",
+            "2024-01-02T00:00:00+00:00",
+            "codexpert",
+            "orchestrator",
+            "Spec",
+            "Goal",
+            json.dumps({"beta": 2}),
+            "completed",
+            "",
+            "2024-01-02T00:00:00+00:00",
+        ],
+    ]
+
+    bus, _, _ = _build_service(values)
+
+    records = bus.poll("sheet-123", "Bus", status="pending", limit=10)
+    assert len(records) == 1
+    record = records[0]
+    assert record["id"] == "msg-1"
+    assert record["status"] == "pending"
+    assert record["context_json"] == {"alpha": 1}
+
+
+def test_update_status_updates_error_and_last_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    fixed_timestamp = datetime(2024, 2, 3, 4, 5, 6, tzinfo=timezone.utc)
+
+    class _FixedDatetime:
+        @classmethod
+        def now(cls, tz: timezone | None = None) -> datetime:
+            assert tz == timezone.utc
+            return fixed_timestamp
+
+    monkeypatch.setattr(bus_service, "datetime", _FixedDatetime)
+
+    values = [
+        ["id", "ts", "from", "to", "topic", "goal", "context_json", "status", "error", "last_update"],
+        [
+            "msg-1",
+            "2024-01-01T00:00:00+00:00",
+            "orchestrator",
+            "codexpert",
+            "Spec",
+            "Goal",
+            json.dumps({"alpha": 1}),
+            "pending",
+            "",
+            "2024-01-01T00:00:00+00:00",
+        ],
+    ]
+
+    bus, values_resource, _ = _build_service(values)
+
+    record = bus.update_status("sheet-123", "Bus", "msg-1", "completed", error="boom")
+
+    assert len(values_resource.update_calls) == 1
+    update_call = values_resource.update_calls[0]
+    assert update_call["range"] == "Bus!H2:J2"
+    assert update_call["body"]["values"][0] == ["completed", "boom", fixed_timestamp.isoformat()]
+
+    assert record == {
+        "id": "msg-1",
+        "ts": "2024-01-01T00:00:00+00:00",
+        "from": "orchestrator",
+        "to": "codexpert",
+        "topic": "Spec",
+        "goal": "Goal",
+        "context_json": {"alpha": 1},
+        "status": "completed",
+        "error": "boom",
+        "last_update": fixed_timestamp.isoformat(),
+    }
+
+
+def test_update_status_raises_when_message_missing() -> None:
+    values = [["id", "ts", "from", "to", "topic", "goal", "context_json", "status", "error", "last_update"]]
+    bus, _, _ = _build_service(values)
+
+    with pytest.raises(BusServiceError):
+        bus.update_status("sheet-123", "Bus", "missing", "done")
+
+
+def test_update_status_keeps_existing_error_when_not_provided(monkeypatch: pytest.MonkeyPatch) -> None:
+    fixed_timestamp = datetime(2024, 3, 4, 5, 6, 7, tzinfo=timezone.utc)
+
+    class _FixedDatetime:
+        @classmethod
+        def now(cls, tz: timezone | None = None) -> datetime:
+            assert tz == timezone.utc
+            return fixed_timestamp
+
+    monkeypatch.setattr(bus_service, "datetime", _FixedDatetime)
+
+    values = [
+        ["id", "ts", "from", "to", "topic", "goal", "context_json", "status", "error", "last_update"],
+        [
+            "msg-1",
+            "2024-01-01T00:00:00+00:00",
+            "orchestrator",
+            "codexpert",
+            "Spec",
+            "Goal",
+            json.dumps({"alpha": 1}),
+            "pending",
+            "previous-error",
+            "2024-01-01T00:00:00+00:00",
+        ],
+    ]
+
+    bus, values_resource, _ = _build_service(values)
+
+    record = bus.update_status("sheet-123", "Bus", "msg-1", "completed")
+
+    assert values_resource.update_calls[0]["body"]["values"][0] == [
+        "completed",
+        "previous-error",
+        fixed_timestamp.isoformat(),
+    ]
+    assert record["error"] == "previous-error"


### PR DESCRIPTION
## Summary
- expose the full bus sheet schema on the FastAPI request/response models
- rewrite the bus service to read/write the A:J range, persist context JSON, and trigger the bus-dispatch workflow
- add unit coverage for the new flow and return a placeholder when the memorial file is absent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda7dafdbc83319e3fb90fa79f4f9d