### PR TITLE
Add structured RAG query responses with metadata

### DIFF
--- a/app/routes/rag.py
+++ b/app/routes/rag.py
@@ -41,8 +41,14 @@ class RAGQueryRequest(BaseModel):
     n_results: int = Field(5, ge=1, le=50)
 
 
+class RAGQueryHit(BaseModel):
+    excerpt: str = Field(..., min_length=1)
+    source: str = Field(..., min_length=1)
+    score: float
+
+
 class RAGQueryResponse(BaseModel):
-    results: Dict[str, Any]
+    results: List[RAGQueryHit] = Field(default_factory=list)
 
 
 @router.post("/rag/index", name="rag.index")

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -31,10 +31,44 @@ class RAGService:
             collection.upsert(ids=ids, documents=texts, metadatas=metadatas)
             return ids
 
-    def query(self, collection_name: str, query_text: str, n_results: int) -> Dict[str, Any]:
+    def query(self, collection_name: str, query_text: str, n_results: int) -> List[Dict[str, Any]]:
         collection = self._client.get_or_create_collection(name=collection_name)
-        result = collection.query(query_texts=[query_text], n_results=n_results)
-        return result
+        raw = collection.query(
+            query_texts=[query_text],
+            n_results=n_results,
+            include=["documents", "metadatas", "distances"],
+        )
+
+        matches: List[Dict[str, Any]] = []
+        documents = raw.get("documents") or []
+        metadatas = raw.get("metadatas") or []
+        distances = raw.get("distances") or []
+
+        for index, document_group in enumerate(documents):
+            metadata_group = metadatas[index] if index < len(metadatas) else []
+            distance_group = distances[index] if index < len(distances) else []
+
+            for position, excerpt in enumerate(document_group or []):
+                metadata = metadata_group[position] if position < len(metadata_group) else {}
+                metadata = metadata or {}
+                source = metadata.get("source")
+                if not source:
+                    continue
+
+                score = 0.0
+                if position < len(distance_group) and distance_group[position] is not None:
+                    raw_score = float(distance_group[position])
+                    score = 1.0 - raw_score if 0.0 <= raw_score <= 1.0 else raw_score
+
+                matches.append(
+                    {
+                        "excerpt": excerpt,
+                        "source": str(source),
+                        "score": score,
+                    }
+                )
+
+        return matches
 
     @staticmethod
     def _normalize_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:

--- a/scripts/api_sentra.py
+++ b/scripts/api_sentra.py
@@ -622,7 +622,7 @@ async def get_memorial(project: str = "sentra_core"):
     memorial_file = safe_join(BASE_DIR, "projects", project_slug, "fichiers", "Z_MEMORIAL.md")
 
     if not memorial_file.exists():
-        raise HTTPException(status_code=404, detail="Z_MEMORIAL.md non trouvé")
+        return PlainTextResponse("Z_MEMORIAL.md non trouvé")
 
     try:
         content = memorial_file.read_text(encoding="utf-8")

--- a/tests/test_rag_service.py
+++ b/tests/test_rag_service.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.dependencies import get_audit_logger, get_rag_service
+from app.main import create_app
+from app.services.rag_service import RAGDocument, RAGService
+
+
+class _DummyAuditLogger:
+    def log(self, *args, **kwargs) -> None:  # pragma: no cover - logging no-op
+        return None
+
+
+@pytest.fixture()
+def rag_service(tmp_path) -> Iterator[RAGService]:
+    service = RAGService(persist_directory=tmp_path / "chroma")
+    yield service
+
+
+@pytest.fixture()
+def rag_client(tmp_path) -> Iterator[TestClient]:
+    app = create_app()
+    service = RAGService(persist_directory=tmp_path / "chroma_api")
+
+    app.dependency_overrides[get_rag_service] = lambda: service
+    app.dependency_overrides[get_audit_logger] = lambda: _DummyAuditLogger()
+
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_rag_service_returns_structured_matches(rag_service: RAGService) -> None:
+    documents = [
+        RAGDocument(
+            doc_id="doc-1",
+            text="Alpha beta gamma",
+            metadata={"source": "notes/doc-1.md"},
+        ),
+        RAGDocument(
+            doc_id="doc-2",
+            text="Delta epsilon zeta",
+            metadata={"source": "notes/doc-2.md"},
+        ),
+    ]
+    rag_service.index("unit", documents)
+
+    matches = rag_service.query("unit", "alpha", n_results=2)
+
+    assert isinstance(matches, list)
+    assert matches
+    assert all("excerpt" in match for match in matches)
+    assert all("source" in match for match in matches)
+    assert all("score" in match for match in matches)
+
+    alpha_match = next((match for match in matches if match["source"] == "notes/doc-1.md"), None)
+    assert alpha_match is not None
+    assert alpha_match["excerpt"] == "Alpha beta gamma"
+    assert isinstance(alpha_match["score"], float)
+
+
+def test_rag_query_endpoint_includes_source_metadata(rag_client: TestClient) -> None:
+    index_payload = {
+        "user": "tester",
+        "agent": "unit",
+        "collection": "integration",
+        "documents": [
+            {
+                "text": "Wizardry of the ancient code",
+                "metadata": {"source": "projects/demo/wizards.md"},
+            },
+            {
+                "text": "The chronicles of diligent testing",
+                "metadata": {"source": "projects/demo/testing.md"},
+            },
+        ],
+    }
+    index_response = rag_client.post("/rag/index", json=index_payload)
+    assert index_response.status_code == 200
+
+    query_payload = {
+        "user": "tester",
+        "collection": "integration",
+        "query": "wizardry",
+        "n_results": 2,
+    }
+    query_response = rag_client.post("/rag/query", json=query_payload)
+    assert query_response.status_code == 200
+
+    body = query_response.json()
+    assert isinstance(body["results"], list)
+    assert body["results"]
+    assert all(hit["source"] for hit in body["results"])
+    assert all(isinstance(hit["score"], float) for hit in body["results"])
+
+    wizard_hit = next((hit for hit in body["results"] if hit["source"] == "projects/demo/wizards.md"), None)
+    assert wizard_hit is not None
+    assert wizard_hit["excerpt"] == "Wizardry of the ancient code"


### PR DESCRIPTION
## Summary
- return structured match dictionaries from the RAG service query, including excerpt, source metadata, and a similarity score
- update the rag query API response schema to require source-bearing hits and add coverage for the service and endpoint
- ensure /get_memorial serves a friendly placeholder instead of a 404 when the memorial file is missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda7e169c883318930917bae20a8f6