### PR TITLE
Refactor tests to cover MCP endpoints and service flows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,62 +1,358 @@
-import json
+from __future__ import annotations
+
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Dict, List
+
+import sys
+import types
+
+if "google" not in sys.modules:
+    google_module = types.ModuleType("google")
+    sys.modules["google"] = google_module
+    oauth2_module = types.ModuleType("google.oauth2")
+    sys.modules["google.oauth2"] = oauth2_module
+    service_account_module = types.ModuleType("google.oauth2.service_account")
+
+    class _StubCredentials:
+        @classmethod
+        def from_service_account_file(cls, *args: Any, **kwargs: Any) -> Any:
+            return object()
+
+    service_account_module.Credentials = _StubCredentials
+    oauth2_module.service_account = service_account_module
+    sys.modules["google.oauth2.service_account"] = service_account_module
+
+if "googleapiclient" not in sys.modules:
+    googleapiclient_module = types.ModuleType("googleapiclient")
+    discovery_module = types.ModuleType("googleapiclient.discovery")
+    http_module = types.ModuleType("googleapiclient.http")
+    errors_module = types.ModuleType("googleapiclient.errors")
+
+    def _build(*args: Any, **kwargs: Any) -> Any:  # pragma: no cover - safety fallback
+        raise RuntimeError("googleapiclient.build should not be used in tests")
+
+    class _MediaInMemoryUpload:
+        def __init__(self, body: bytes, mimetype: str | None = None, resumable: bool = False) -> None:
+            self.body = body
+            self.mimetype = mimetype
+            self.resumable = resumable
+
+    discovery_module.build = _build
+    http_module.MediaInMemoryUpload = _MediaInMemoryUpload
+    class _HttpError(Exception):
+        pass
+
+    errors_module.HttpError = _HttpError
+
+    googleapiclient_module.discovery = discovery_module
+    googleapiclient_module.http = http_module
+    googleapiclient_module.errors = errors_module
+    sys.modules["googleapiclient"] = googleapiclient_module
+    sys.modules["googleapiclient.discovery"] = discovery_module
+    sys.modules["googleapiclient.http"] = http_module
+    sys.modules["googleapiclient.errors"] = errors_module
+
+if "chromadb" not in sys.modules:
+    chromadb_module = types.ModuleType("chromadb")
+
+    class _StubCollection:
+        def __init__(self) -> None:
+            self.records: Dict[str, Dict[str, Any]] = {}
+
+        def upsert(self, *, ids: List[str], documents: List[str], metadatas: List[Dict[str, Any]]) -> None:
+            for doc_id, doc_text, metadata in zip(ids, documents, metadatas):
+                self.records[doc_id] = {"document": doc_text, "metadata": metadata}
+
+        def query(self, *, query_texts: List[str], n_results: int) -> Dict[str, Any]:
+            return {"ids": [[]], "documents": [[]], "metadatas": [[]]}
+
+    class _PersistentClient:
+        def __init__(self, path: str) -> None:
+            self.path = path
+            self._collections: Dict[str, _StubCollection] = {}
+
+        def get_or_create_collection(self, name: str) -> _StubCollection:
+            return self._collections.setdefault(name, _StubCollection())
+
+    chromadb_module.PersistentClient = _PersistentClient
+    sys.modules["chromadb"] = chromadb_module
 
 import pytest
 from fastapi.testclient import TestClient
 
-import app.routes.correction as correction
-import scripts.api_sentra as api
+from app import dependencies as dependencies_module
+from app.main import create_app
+from app.services import paths as paths_module
+from app.services.bus_service import BusServiceError
+from app.services.memory_store import MemoryStore
+
+
+class DummyAuditLogger:
+    def __init__(self) -> None:
+        self.events: List[Dict[str, Any]] = []
+
+    def log(self, tool_name: str, args: Dict[str, Any] | None, user: str) -> None:
+        self.events.append({"tool": tool_name, "args": args, "user": user})
+
+
+class DummyGitHelper:
+    def __init__(self) -> None:
+        self.commits: List[Dict[str, Any]] = []
+
+    def commit_and_push(self, tool: str, file_path: Path, agent: str, content_hash: str) -> str:
+        path = Path(file_path)
+        message = f"[{tool}] {path.name} {content_hash} by {agent}"
+        self.commits.append(
+            {
+                "tool": tool,
+                "file": path,
+                "agent": agent,
+                "hash": content_hash,
+                "message": message,
+            }
+        )
+        return message
+
+
+class DummyExecute:
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self._payload = payload
+
+    def execute(self) -> Dict[str, Any]:
+        return dict(self._payload)
+
+
+class DummyCalendarService:
+    def __init__(self) -> None:
+        self.created_events: List[Dict[str, Any]] = []
+
+    class _EventsAPI:
+        def __init__(self, service: "DummyCalendarService") -> None:
+            self._service = service
+
+        def insert(
+            self,
+            *,
+            calendarId: str,
+            body: Dict[str, Any],
+            supportsAttachments: bool,
+            sendUpdates: str,
+        ) -> DummyExecute:
+            event_id = body.get("id") or f"event-{len(self._service.created_events) + 1}"
+            event = {
+                "id": event_id,
+                "calendarId": calendarId,
+                "body": body,
+                "htmlLink": f"https://calendar.google.com/event?eid={event_id}",
+                "status": "confirmed",
+            }
+            self._service.created_events.append(event)
+            return DummyExecute({"id": event["id"], "htmlLink": event["htmlLink"], "status": event["status"]})
+
+    def events(self) -> "DummyCalendarService._EventsAPI":
+        return DummyCalendarService._EventsAPI(self)
+
+
+class DummyDriveService:
+    def __init__(self) -> None:
+        self.uploads: List[Dict[str, Any]] = []
+
+    class _FilesAPI:
+        def __init__(self, service: "DummyDriveService") -> None:
+            self._service = service
+
+        def create(self, *, body: Dict[str, Any], media_body: Dict[str, Any], fields: str) -> DummyExecute:
+            file_id = body.get("id") or f"file-{len(self._service.uploads) + 1}"
+            record = {
+                "id": file_id,
+                "body": dict(body),
+                "media": dict(media_body),
+                "webViewLink": f"https://drive.google.com/file/d/{file_id}",
+            }
+            self._service.uploads.append(record)
+            return DummyExecute({"id": record["id"], "webViewLink": record["webViewLink"]})
+
+    def files(self) -> "DummyDriveService._FilesAPI":
+        return DummyDriveService._FilesAPI(self)
+
+
+class DummyGoogleAuthManager:
+    def __init__(self) -> None:
+        self.calendar = DummyCalendarService()
+        self.drive = DummyDriveService()
+
+    def calendar_service(self) -> DummyCalendarService:
+        return self.calendar
+
+    def drive_service(self) -> DummyDriveService:
+        return self.drive
+
+    @staticmethod
+    def build_media(body: bytes, mime_type: str) -> Dict[str, Any]:
+        return {"body": body, "mime_type": mime_type}
+
+
+@dataclass
+class DummyBusRecord:
+    spreadsheet_id: str
+    worksheet: str
+    message_id: str
+    timestamp: str
+    user: str
+    agent: str
+    status: str
+    payload: Dict[str, Any]
+
+
+class DummyBusService:
+    def __init__(self) -> None:
+        self.records: List[DummyBusRecord] = []
+
+    def send(
+        self,
+        *,
+        spreadsheet_id: str,
+        worksheet: str,
+        payload: Dict[str, Any],
+        user: str,
+        agent: str,
+        idempotency_key: str | None = None,
+    ) -> Dict[str, Any]:
+        message_id = idempotency_key or f"msg-{len(self.records) + 1}"
+        timestamp = f"2024-01-01T00:00:{len(self.records):02d}Z"
+        record = DummyBusRecord(
+            spreadsheet_id=spreadsheet_id,
+            worksheet=worksheet,
+            message_id=message_id,
+            timestamp=timestamp,
+            user=user,
+            agent=agent,
+            status="pending",
+            payload=dict(payload),
+        )
+        self.records.append(record)
+        return {"message_id": message_id, "status": record.status, "timestamp": timestamp}
+
+    def poll(
+        self,
+        *,
+        spreadsheet_id: str,
+        worksheet: str,
+        status: str | None,
+        limit: int,
+    ) -> List[Dict[str, Any]]:
+        results: List[Dict[str, Any]] = []
+        for record in self.records:
+            if record.spreadsheet_id != spreadsheet_id or record.worksheet != worksheet:
+                continue
+            if status and record.status.lower() != status.lower():
+                continue
+            results.append(
+                {
+                    "message_id": record.message_id,
+                    "timestamp": record.timestamp,
+                    "user": record.user,
+                    "agent": record.agent,
+                    "status": record.status,
+                    "payload": dict(record.payload),
+                }
+            )
+            if len(results) >= limit:
+                break
+        return results
+
+    def update_status(
+        self,
+        *,
+        spreadsheet_id: str,
+        worksheet: str,
+        message_id: str,
+        status: str,
+    ) -> Dict[str, Any]:
+        for record in self.records:
+            if (
+                record.spreadsheet_id == spreadsheet_id
+                and record.worksheet == worksheet
+                and record.message_id == message_id
+            ):
+                record.status = status
+                return {"message_id": message_id, "status": status}
+        raise BusServiceError(f"Message {message_id} not found")
+
+
+class DummyRAGService:
+    def __init__(self) -> None:
+        self.collections: Dict[str, Dict[str, Dict[str, Any]]] = {}
+
+    def index(self, collection_name: str, documents: List[Any]) -> List[str]:
+        collection = self.collections.setdefault(collection_name, {})
+        ids: List[str] = []
+        for document in documents:
+            ids.append(document.doc_id)
+            collection[document.doc_id] = {"text": document.text, "metadata": dict(document.metadata)}
+        return ids
+
+    def query(self, collection_name: str, query_text: str, n_results: int) -> Dict[str, Any]:
+        collection = self.collections.get(collection_name, {})
+        matches: List[str] = []
+        lowered = query_text.lower()
+        for doc_id, payload in collection.items():
+            if lowered in payload["text"].lower():
+                matches.append(doc_id)
+            if len(matches) >= n_results:
+                break
+        documents = [[collection[mid]["text"] for mid in matches]]
+        metadatas = [[collection[mid]["metadata"] for mid in matches]]
+        return {"ids": [matches], "documents": documents, "metadatas": metadatas}
 
 
 @pytest.fixture
 def api_context(tmp_path, monkeypatch):
     base_dir = tmp_path / "sentra"
-    for sub in ("projects", "memory", "logs", "archive"):
-        (base_dir / sub).mkdir(parents=True, exist_ok=True)
+    for subdir in ("projects", "reports", "students", "logs", "memory", "archive"):
+        (base_dir / subdir).mkdir(parents=True, exist_ok=True)
 
-    commits: list[dict[str, object]] = []
+    monkeypatch.setattr(paths_module, "BASE_DIR", base_dir)
+    monkeypatch.setattr(
+        paths_module,
+        "ALLOWED_ROOTS",
+        {
+            "projects": base_dir / "projects",
+            "reports": base_dir / "reports",
+            "students": base_dir / "students",
+        },
+    )
 
-    def fake_git_commit_push(paths, message):
-        normalized = [Path(p) for p in paths]
-        commits.append({"paths": normalized, "message": message})
+    audit_logger = DummyAuditLogger()
+    git_helper = DummyGitHelper()
+    memory_store = MemoryStore(base_dir / "memory")
+    bus_service = DummyBusService()
+    google_manager = DummyGoogleAuthManager()
+    rag_service = DummyRAGService()
 
-    monkeypatch.setattr(api, "git_commit_push", fake_git_commit_push)
-
-    def fake_search_memory(term: str, max_results: int = 5):
-        mem_file = base_dir / "memory" / "sentra_memory.json"
-        if not mem_file.exists():
-            return []
-        data = json.loads(mem_file.read_text(encoding="utf-8"))
-        results: list[str] = []
-        for entry in data:
-            if term.lower() in entry.get("text", "").lower():
-                ts = entry.get("timestamp", "now")
-                results.append(f"- [{ts}] {entry['text']}")
-            if len(results) >= max_results:
-                break
-        return results
-
-    monkeypatch.setattr(api, "search_memory", fake_search_memory)
-
-    def fake_query_memory(limit: int):
-        mem_file = base_dir / "memory" / "sentra_memory.json"
-        if not mem_file.exists():
-            return []
-        data = json.loads(mem_file.read_text(encoding="utf-8"))
-        return data[-limit:]
-
-    monkeypatch.setattr(api, "query_memory", fake_query_memory)
-
-    monkeypatch.setattr(api, "BASE_DIR", base_dir)
-
-    sandbox_root = (base_dir / "sandbox" / "SENTRA_SANDBOX").resolve()
-    sandbox_root.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(correction, "ALLOWED_BASE_DIR", str(sandbox_root))
-
-    return {"base_dir": base_dir, "commits": commits, "sandbox": sandbox_root}
+    return {
+        "base_dir": base_dir,
+        "audit_logger": audit_logger,
+        "audit_events": audit_logger.events,
+        "git_helper": git_helper,
+        "git_commits": git_helper.commits,
+        "memory_store": memory_store,
+        "bus_service": bus_service,
+        "google_manager": google_manager,
+        "rag_service": rag_service,
+    }
 
 
 @pytest.fixture
 def client(api_context):
-    with TestClient(api.app) as test_client:
+    app = create_app()
+    app.dependency_overrides[dependencies_module.get_audit_logger] = lambda: api_context["audit_logger"]
+    app.dependency_overrides[dependencies_module.get_git_helper] = lambda: api_context["git_helper"]
+    app.dependency_overrides[dependencies_module.get_memory_store] = lambda: api_context["memory_store"]
+    app.dependency_overrides[dependencies_module.get_bus_service] = lambda: api_context["bus_service"]
+    app.dependency_overrides[dependencies_module.get_google_auth_manager] = lambda: api_context["google_manager"]
+    app.dependency_overrides[dependencies_module.get_rag_service] = lambda: api_context["rag_service"]
+    with TestClient(app) as test_client:
         yield test_client
+    app.dependency_overrides.clear()

--- a/tests/test_e2e_workflow.py
+++ b/tests/test_e2e_workflow.py
@@ -1,71 +1,194 @@
 from __future__ import annotations
 
-from pathlib import Path
+import base64
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 
 @pytest.mark.slow
-def test_full_workflow_through_filesystem_and_memory(client, api_context):
-    base_dir = api_context["base_dir"]
-
+def test_full_workflow_using_mcp_endpoints(client, api_context):
     note_text = "Organizer hands-off spec to CodeXpert"
     note_response = client.post(
-        "/write_note",
-        json={"text": note_text, "project": "demo"},
+        "/memory/note/add",
+        json={
+            "user": "operator",
+            "agent": "scribe",
+            "note": {
+                "text": note_text,
+                "tags": ["handoff", "spec"],
+                "metadata": {"channel": "ops"},
+            },
+        },
     )
     assert note_response.status_code == 200
+    note_payload = note_response.json()["note"]
+    assert note_payload["text"] == note_text
 
-    spec_body = "Initial spec drafted for CodeXpert"
-    create_response = client.post(
-        "/write_file",
-        json={"project": "demo", "filename": "handoff/spec.md", "content": spec_body},
-    )
-    assert create_response.status_code == 200
-    handoff_path = Path(create_response.json()["path"])
-    assert handoff_path.exists()
-
-    move_response = client.post(
-        "/move_file",
+    spec_content = "Initial spec drafted for CodeXpert"
+    write_response = client.post(
+        "/files/write",
         json={
-            "src": "projects/demo/fichiers/handoff/spec.md",
-            "dst": "projects/demo/fichiers/review/spec.md",
+            "user": "operator",
+            "agent": "scribe",
+            "path": "/projects/demo/docs/spec.md",
+            "content": spec_content,
         },
     )
-    assert move_response.status_code == 200
-    assert move_response.json()["status"] == "success"
+    assert write_response.status_code == 200
+    written_path = write_response.json()["path"]
 
-    archive_response = client.post(
-        "/archive_file",
-        json={
-            "path": "projects/demo/fichiers/review/spec.md",
-            "archive_dir": "archive/demo",
-        },
+    read_response = client.post(
+        "/files/read",
+        json={"user": "operator", "path": "/projects/demo/docs/spec.md"},
     )
-    assert archive_response.status_code == 200
-    assert archive_response.json()["status"] == "success"
-
-    read_response = client.get("/read_note", params={"term": "hands-off"})
     assert read_response.status_code == 200
-    data = read_response.json()
-    assert data["status"] == "success"
-    combined = " ".join(data["results"]).lower()
-    assert "organizer hands-off" in combined
+    assert spec_content in read_response.json()["content"]
 
-    search_response = client.get(
-        "/search",
-        params={"term": "Initial spec", "dir": "archive/demo"},
+    find_response = client.post(
+        "/memory/note/find",
+        json={"user": "operator", "query": "CodeXpert", "tags": [], "limit": 5},
     )
-    assert search_response.status_code == 200
-    archived_path = base_dir / "archive" / "demo" / "spec.md"
-    assert str(archived_path) in search_response.json()["matches"]
+    assert find_response.status_code == 200
+    matches = [entry["text"] for entry in find_response.json()["results"]]
+    assert any(note_text in item for item in matches)
 
-    memorial_response = client.get("/get_memorial", params={"project": "demo"})
-    assert memorial_response.status_code == 200
-    assert "Organizer hands-off" in memorial_response.text
+    commits = [entry["message"] for entry in api_context["git_commits"]]
+    assert any("files.write" in message for message in commits)
+    assert any(event["tool"] == "memory.note.add" for event in api_context["audit_events"])
 
-    commit_messages = [entry["message"] for entry in api_context["commits"]]
-    assert any("GPT note" in message for message in commit_messages)
-    assert any("GPT file update" in message for message in commit_messages)
-    assert any("GPT move" in message for message in commit_messages)
-    assert any("GPT archive" in message for message in commit_messages)
+    persisted = api_context["base_dir"] / "projects" / "demo" / "docs" / "spec.md"
+    assert persisted.exists() and persisted.read_text(encoding="utf-8") == spec_content
+    assert written_path == str(persisted)
+
+
+def test_bus_flow_covering_send_poll_and_update(client, api_context):
+    send_response = client.post(
+        "/bus/send",
+        json={
+            "user": "operator",
+            "agent": "dispatcher",
+            "spreadsheet_id": "sheet-1",
+            "worksheet": "Requests",
+            "payload": {"title": "Onboarding"},
+        },
+    )
+    assert send_response.status_code == 200
+    send_payload = send_response.json()
+    message_id = send_payload["message_id"]
+    assert send_payload["status"] == "pending"
+
+    update_response = client.post(
+        "/bus/updateStatus",
+        json={
+            "user": "operator",
+            "agent": "dispatcher",
+            "spreadsheet_id": "sheet-1",
+            "worksheet": "Requests",
+            "message_id": message_id,
+            "status": "done",
+        },
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["status"] == "done"
+
+    poll_response = client.post(
+        "/bus/poll",
+        json={
+            "user": "operator",
+            "spreadsheet_id": "sheet-1",
+            "worksheet": "Requests",
+            "status": "done",
+            "limit": 5,
+        },
+    )
+    assert poll_response.status_code == 200
+    records = poll_response.json()["records"]
+    assert len(records) == 1
+    assert records[0]["message_id"] == message_id
+    assert records[0]["status"] == "done"
+
+    assert any(event["tool"].startswith("bus.") for event in api_context["audit_events"])
+
+
+def test_google_flow_for_calendar_and_drive(client, api_context):
+    start = datetime.now(timezone.utc).replace(microsecond=0)
+    end = start + timedelta(hours=1)
+
+    calendar_response = client.post(
+        "/google/gcal/create_event",
+        json={
+            "user": "operator",
+            "agent": "scheduler",
+            "calendar_id": "primary",
+            "summary": "Project Sync",
+            "description": "Discuss launch",
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "timezone": "UTC",
+            "attendees": ["lead@example.com"],
+            "idempotency_key": "sync-1",
+        },
+    )
+    assert calendar_response.status_code == 200
+    event_payload = calendar_response.json()
+    assert event_payload["event_id"] == "sync-1"
+    assert event_payload["status"] == "confirmed"
+
+    encoded = base64.b64encode(b"Spec summary").decode("ascii")
+    drive_response = client.post(
+        "/google/gdrive/upload",
+        json={
+            "user": "operator",
+            "agent": "scheduler",
+            "name": "summary.txt",
+            "mime_type": "text/plain",
+            "content_base64": encoded,
+            "folder_id": "folder-1",
+        },
+    )
+    assert drive_response.status_code == 200
+    file_payload = drive_response.json()
+    assert file_payload["file_id"].startswith("file-")
+
+    calendar_records = api_context["google_manager"].calendar.created_events
+    assert any(entry["body"]["summary"] == "Project Sync" for entry in calendar_records)
+    drive_records = api_context["google_manager"].drive.uploads
+    assert any(upload["body"]["name"] == "summary.txt" for upload in drive_records)
+
+
+def test_rag_index_and_query_flow(client, api_context):
+    index_response = client.post(
+        "/rag/index",
+        json={
+            "user": "operator",
+            "agent": "researcher",
+            "collection": "handbook",
+            "documents": [
+                {"text": "SENTRA handbook overview", "metadata": {"section": "intro"}},
+                {
+                    "text": "Troubleshooting CodeXpert workflows",
+                    "metadata": {"section": "support"},
+                },
+            ],
+        },
+    )
+    assert index_response.status_code == 200
+    indexed_ids = index_response.json()["document_ids"]
+    assert len(indexed_ids) == 2
+
+    query_response = client.post(
+        "/rag/query",
+        json={
+            "user": "operator",
+            "collection": "handbook",
+            "query": "CodeXpert",
+            "n_results": 3,
+        },
+    )
+    assert query_response.status_code == 200
+    rag_results = query_response.json()["results"]
+    assert any("CodeXpert" in doc for doc in rag_results["documents"][0])
+
+    rag_collection = api_context["rag_service"].collections["handbook"]
+    assert set(rag_collection) == set(indexed_ids)


### PR DESCRIPTION
## Summary
- replace the shared testing fixtures with MCP-aware stubs for git, audit, Google, bus, and RAG services
- rewrite filesystem and memory router tests to exercise the new /files and /memory MCP endpoints
- expand the end-to-end workflow suite with coverage for bus, Google Calendar/Drive, and RAG flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda7e282b08331ae409aa50dedb450