### PR TITLE
Phase 4 — Bus slim ({message_id,status,timestamp}) + metadata

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -311,14 +311,15 @@ components:
           type: "string"
           minLength: 1
           title: "User"
-        spreadsheet_id:
+        agent:
           type: "string"
           minLength: 1
-          title: "Spreadsheet Id"
-        worksheet:
-          type: "string"
-          minLength: 1
-          title: "Worksheet"
+          title: "Agent"
+        metadata:
+          additionalProperties: true
+          type: "object"
+          title: "Metadata"
+          default: {}
         status:
           anyOf:
             -
@@ -335,8 +336,7 @@ components:
       type: "object"
       required:
         - "user"
-        - "spreadsheet_id"
-        - "worksheet"
+        - "agent"
       title: "BusPollRequest"
     BusPollResponse:
       properties:
@@ -389,18 +389,16 @@ components:
           type: "string"
           minLength: 1
           title: "Agent"
-        spreadsheet_id:
-          type: "string"
-          minLength: 1
-          title: "Spreadsheet Id"
-        worksheet:
-          type: "string"
-          minLength: 1
-          title: "Worksheet"
         payload:
           additionalProperties: true
           type: "object"
           title: "Payload"
+          default: {}
+        metadata:
+          additionalProperties: true
+          type: "object"
+          title: "Metadata"
+          default: {}
         idempotency_key:
           anyOf:
             -
@@ -412,8 +410,6 @@ components:
       required:
         - "user"
         - "agent"
-        - "spreadsheet_id"
-        - "worksheet"
       title: "BusSendRequest"
     BusSendResponse:
       properties:
@@ -442,14 +438,11 @@ components:
           type: "string"
           minLength: 1
           title: "Agent"
-        spreadsheet_id:
-          type: "string"
-          minLength: 1
-          title: "Spreadsheet Id"
-        worksheet:
-          type: "string"
-          minLength: 1
-          title: "Worksheet"
+        metadata:
+          additionalProperties: true
+          type: "object"
+          title: "Metadata"
+          default: {}
         message_id:
           type: "string"
           minLength: 1
@@ -458,12 +451,17 @@ components:
           type: "string"
           minLength: 1
           title: "Status"
+        error:
+          anyOf:
+            -
+              type: "string"
+            -
+              type: "null"
+          title: "Error"
       type: "object"
       required:
         - "user"
         - "agent"
-        - "spreadsheet_id"
-        - "worksheet"
         - "message_id"
         - "status"
       title: "BusUpdateStatusRequest"

--- a/tests/test_e2e_workflow.py
+++ b/tests/test_e2e_workflow.py
@@ -68,9 +68,8 @@ def test_bus_flow_covering_send_poll_and_update(client, api_context):
         json={
             "user": "operator",
             "agent": "dispatcher",
-            "spreadsheet_id": "sheet-1",
-            "worksheet": "Requests",
             "payload": {"title": "Onboarding"},
+            "metadata": {"spreadsheet_id": "sheet-1", "worksheet": "Requests"},
         },
     )
     assert send_response.status_code == 200
@@ -83,10 +82,9 @@ def test_bus_flow_covering_send_poll_and_update(client, api_context):
         json={
             "user": "operator",
             "agent": "dispatcher",
-            "spreadsheet_id": "sheet-1",
-            "worksheet": "Requests",
             "message_id": message_id,
             "status": "done",
+            "metadata": {"spreadsheet_id": "sheet-1", "worksheet": "Requests"},
         },
     )
     assert update_response.status_code == 200
@@ -96,10 +94,10 @@ def test_bus_flow_covering_send_poll_and_update(client, api_context):
         "/bus/poll",
         json={
             "user": "operator",
-            "spreadsheet_id": "sheet-1",
-            "worksheet": "Requests",
+            "agent": "dispatcher",
             "status": "done",
             "limit": 5,
+            "metadata": {"spreadsheet_id": "sheet-1", "worksheet": "Requests"},
         },
     )
     assert poll_response.status_code == 200


### PR DESCRIPTION
Modifs poussées sur fix/phase4-bus-slim :

app/routes/bus.py : nouveaux modèles Phase 4 (metadata + suppression spreadsheet_id/worksheet publics) et réponses {message_id,status,timestamp}.
openapi.yaml : schémas Bus synchronisés (payload/metadata par défaut {}, champs requis mis à jour).
tests/test_e2e_workflow.py : scénarios Bus ajustés (metadata fournie côté client).
Tests : python -m pytest -q (24 passed, warnings httpx). Branche disponible ici : https://github.com/NexorAgent/SENTRA_CORE_MEM/pull/new/fix/phase4-bus-slim